### PR TITLE
Do not parse FQN usages for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All this can be ensured by [slevomat/coding-standard](https://github.com/slevoma
 </ruleset>
 ```
 
-Basically, this tool extracts used symbols just from use statements and FQNs (PHP8+) and compare those with your composer dependencies.
+Basically, this tool extracts used symbols just from use statements and compare those with your composer dependencies.
 
 ## Usage:
 

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -60,10 +60,6 @@ class UsedSymbolExtractor
                     $statements[] = $usedClass;
                 }
             }
-
-            if (PHP_VERSION_ID >= 80000 && $token[0] === T_NAME_FULLY_QUALIFIED) {
-                $statements[] = $this->normalizeBackslash($token[1]);
-            }
         }
 
         return $statements;

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -4,7 +4,6 @@ namespace ShipMonk\Composer;
 
 use PHPUnit\Framework\TestCase;
 use function file_get_contents;
-use const PHP_VERSION_ID;
 
 class UsedSymbolExtractorTest extends TestCase
 {
@@ -21,10 +20,6 @@ class UsedSymbolExtractorTest extends TestCase
             'Aliased\Classname',
             'Aliased\Classname2',
         ];
-
-        if (PHP_VERSION_ID >= 80000) {
-            $expected[] = 'Fully\Qualified\ClassName';
-        }
 
         self::assertSame($expected, $extractor->parseUsedSymbols());
     }

--- a/tests/data/use-statements.php
+++ b/tests/data/use-statements.php
@@ -47,3 +47,6 @@ new Not\Fully\Qualified\ClassName();
 namespace Bar {
     use WithinBracketNamespace; // not supported
 }
+
+
+\DIRECTORY_SEPARATOR;


### PR DESCRIPTION
This token lacks info about its type (it can be e.g. const). That is very hard to detect just from tokens. We might autoload it by class_exists, but that degrades performance.