### PR TITLE
Detect autoloadable classes not present on classmap

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -33,6 +33,7 @@ use function realpath;
 use function sort;
 use function str_replace;
 use function strlen;
+use function strpos;
 use function strtolower;
 use function substr;
 use function trim;
@@ -460,12 +461,15 @@ class Analyser
             return false; // should probably never happen as internal classes are handled earlier
         }
 
-        try {
-            $this->optimizedClassmap[$usedSymbol] = $this->realPath($filePath);
-            return true;
-        } catch (InvalidPathException $e) {
-            return false; // unable to realpath filepath from reflection, probably cannot happen
+        $pharPrefix = 'phar://';
+
+        if (strpos($filePath, $pharPrefix) === 0) {
+            /** @var string $filePath */
+            $filePath = substr($filePath, strlen($pharPrefix));
         }
+
+        $this->optimizedClassmap[$usedSymbol] = $filePath;
+        return true;
     }
 
 }

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -42,13 +42,8 @@ class AnalyserTest extends TestCase
         $config = new Configuration();
         $editConfig($config);
 
-        $stopwatch = $this->createMock(Stopwatch::class);
-        $stopwatch->expects(self::once())
-            ->method('stop')
-            ->willReturn(0.0);
-
         $detector = new Analyser(
-            $stopwatch,
+            $this->getStopwatchMock(),
             $config,
             $vendorDir,
             $classmap,
@@ -467,13 +462,8 @@ class AnalyserTest extends TestCase
         $config = new Configuration();
         $config->addPathToScan($path, false);
 
-        $stopwatch = $this->createMock(Stopwatch::class);
-        $stopwatch->expects(self::once())
-            ->method('stop')
-            ->willReturn(0.0);
-
         $detector = new Analyser(
-            $stopwatch,
+            $this->getStopwatchMock(),
             $config,
             __DIR__,
             [],
@@ -489,6 +479,38 @@ class AnalyserTest extends TestCase
                 ],
             ],
         ]), $result);
+    }
+
+    public function testAutoloadableClassNotInClassmap(): void
+    {
+        require __DIR__ . '/vendor/dev/package/Clazz.php';
+
+        $path = realpath(__DIR__ . '/data/autoloadable-no-classmap/usage.php');
+        self::assertNotFalse($path);
+
+        $config = new Configuration();
+        $config->addPathToScan($path, true);
+
+        $detector = new Analyser(
+            $this->getStopwatchMock(),
+            $config,
+            __DIR__ . '/vendor',
+            [],
+            ['dev/package' => true]
+        );
+        $result = $detector->run();
+
+        self::assertEquals($this->createAnalysisResult(1, []), $result);
+    }
+
+    private function getStopwatchMock(): Stopwatch
+    {
+        $stopwatch = $this->createMock(Stopwatch::class);
+        $stopwatch->expects(self::once())
+            ->method('stop')
+            ->willReturn(0.0);
+
+        return $stopwatch;
     }
 
 }

--- a/tests/data/autoloadable-no-classmap/usage.php
+++ b/tests/data/autoloadable-no-classmap/usage.php
@@ -1,0 +1,3 @@
+<?php
+
+\Dev\Package\Clazz::class;


### PR DESCRIPTION
- Resolves #50 
- Adds support for locating classes within phars (e.g. PHPStan classes).