### PR TITLE
Remove requirement of optimized classmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ composer require --dev shipmonk/composer-dependency-analyser
 ## Usage:
 
 ```sh
-composer dump-autoload --classmap-authoritative # we use composer's autoloader to detect which class belongs to which package
 vendor/bin/composer-dependency-analyser
 ```
 

--- a/bin/composer-dependency-analyser
+++ b/bin/composer-dependency-analyser
@@ -162,7 +162,7 @@ try {
     }
 
     $stopwatch = new Stopwatch();
-    $analyser = new Analyser($stopwatch, $config, $vendorDir, $composerJson->dependencies, $loaders[$vendorDir]->getClassMap());
+    $analyser = new Analyser($stopwatch, $config, $vendorDir, $composerJson->dependencies);
     $result = $analyser->run();
 } catch (OurRuntimeException $e) {
     $exit($e->getMessage());

--- a/bin/composer-dependency-analyser
+++ b/bin/composer-dependency-analyser
@@ -146,10 +146,6 @@ if (count($loaders) !== 1) {
 }
 $vendorDir = key($loaders);
 
-if (!$loaders[$vendorDir]->isClassMapAuthoritative()) {
-    $exit('Run \'composer dump-autoload --classmap-authoritative\' first');
-}
-
 try {
     if ($config->shouldScanComposerAutoloadPaths()) {
         foreach ($composerJson->autoloadPaths as $absolutePath => $isDevPath) {
@@ -166,7 +162,7 @@ try {
     }
 
     $stopwatch = new Stopwatch();
-    $analyser = new Analyser($stopwatch, $config, $vendorDir, $loaders[$vendorDir]->getClassMap(), $composerJson->dependencies);
+    $analyser = new Analyser($stopwatch, $config, $vendorDir, $composerJson->dependencies, $loaders[$vendorDir]->getClassMap());
     $result = $analyser->run();
 } catch (OurRuntimeException $e) {
     $exit($e->getMessage());

--- a/composer.json
+++ b/composer.json
@@ -73,10 +73,7 @@
         "check:composer": "composer normalize --dry-run --no-check-lock --no-update-lock",
         "check:cs": "phpcs",
         "check:ec": "ec src tests",
-        "check:self": [
-            "composer dump -a",
-            "bin/composer-dependency-analyser"
-        ],
+        "check:self": "bin/composer-dependency-analyser",
         "check:tests": "phpunit -vvv tests",
         "check:types": "phpstan analyse -vvv --ansi",
         "fix:cs": "phpcbf"

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -127,15 +127,8 @@ class Analyser
                 }
 
                 if (!$this->isInClassmap($usedSymbol)) {
-                    $addedToClassmapManually = false;
-
-                    if ($this->isAutoloadableClass($usedSymbol)) {
-                        $addedToClassmapManually = $this->addToClassmap($usedSymbol);
-                    }
-
                     if (
-                        !$addedToClassmapManually
-                        && !$this->isConstOrFunction($usedSymbol)
+                        !$this->isConstOrFunction($usedSymbol)
                         && !$this->isNativeType($usedSymbol)
                         && !$ignoreList->shouldIgnoreUnknownClass($usedSymbol, $filePath)
                     ) {
@@ -144,9 +137,7 @@ class Analyser
                         }
                     }
 
-                    if (!$addedToClassmapManually) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 $classmapPath = $this->getPathFromClassmap($usedSymbol);
@@ -370,7 +361,13 @@ class Analyser
 
     private function isInClassmap(string $usedSymbol): bool
     {
-        return isset($this->classmap[$usedSymbol]);
+        $foundInClassmap = isset($this->classmap[$usedSymbol]);
+
+        if (!$foundInClassmap && $this->isAutoloadableClass($usedSymbol)) {
+            return $this->addToClassmap($usedSymbol);
+        }
+
+        return $foundInClassmap;
     }
 
     private function getPathFromClassmap(string $usedSymbol): string

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -46,8 +46,8 @@ class AnalyserTest extends TestCase
             $this->getStopwatchMock(),
             $config,
             $vendorDir,
-            $classmap,
-            $dependencies
+            $dependencies,
+            $classmap
         );
         $result = $detector->run();
 
@@ -495,8 +495,8 @@ class AnalyserTest extends TestCase
             $this->getStopwatchMock(),
             $config,
             __DIR__ . '/vendor',
-            [],
-            ['dev/package' => true]
+            ['dev/package' => true],
+            []
         );
         $result = $detector->run();
 

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -484,18 +484,23 @@ class AnalyserTest extends TestCase
     public function testAutoloadableClassNotInClassmap(): void
     {
         require __DIR__ . '/vendor/dev/package/Clazz.php';
+        require __DIR__ . '/vendor/regular/package/Clazz.php';
 
         $path = realpath(__DIR__ . '/data/autoloadable-no-classmap/usage.php');
         self::assertNotFalse($path);
 
         $config = new Configuration();
         $config->addPathToScan($path, true);
+        $config->addForceUsedSymbol('Regular\Package\Clazz');
 
         $detector = new Analyser(
             $this->getStopwatchMock(),
             $config,
             __DIR__ . '/vendor',
-            ['dev/package' => true],
+            [
+                'regular/package' => false,
+                'dev/package' => true
+            ],
             []
         );
         $result = $detector->run();

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -466,7 +466,6 @@ class AnalyserTest extends TestCase
             $this->getStopwatchMock(),
             $config,
             __DIR__,
-            [],
             []
         );
         $result = $detector->run();
@@ -500,8 +499,7 @@ class AnalyserTest extends TestCase
             [
                 'regular/package' => false,
                 'dev/package' => true
-            ],
-            []
+            ]
         );
         $result = $detector->run();
 
@@ -521,7 +519,6 @@ class AnalyserTest extends TestCase
             $this->getStopwatchMock(),
             $config,
             __DIR__ . '/vendor',
-            [],
             []
         );
         $result = $detector->run();

--- a/tests/BinTest.php
+++ b/tests/BinTest.php
@@ -23,8 +23,6 @@ class BinTest extends TestCase
         $okOutput = 'No composer issues found';
         $helpOutput = 'Usage:';
 
-        $this->runCommand('composer dump-autoload --classmap-authoritative', $rootDir, 0, 'Generated optimized autoload files');
-
         $this->runCommand('php bin/composer-dependency-analyser', $rootDir, 0, $okOutput);
         $this->runCommand('php bin/composer-dependency-analyser --verbose', $rootDir, 0, $okOutput);
         $this->runCommand('php ../bin/composer-dependency-analyser', $testsDir, 255, $noComposerJsonError);


### PR DESCRIPTION
We added autoloading in #51. Any autoload obviously degrades performance of this tool. But, generating optimized classmap is actually taking more time then the time saved by not doing autoloads. See measurements on 15k files codebase:

```
time vendor/bin/composer-dependency-analyser # 3.712s (autoloads 10000 classes)

# vs

time composer dump -a                        # 5.619s
time vendor/bin/composer-dependency-analyser # 2.391s (autoloads 70 classes)
```

So the tool will be slower, but overall time needed to get results will be lower and the usage will be easier.