### PR TITLE
AnalyserTest: fix param order

### DIFF
--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -546,7 +546,6 @@ class AnalyserTest extends TestCase
             $this->getStopwatchMock(),
             $config,
             __DIR__ . '/vendor',
-            [],
             [
                 'regular/package' => false,
                 'dev/package' => true


### PR DESCRIPTION
"Require branches to be up to date before merging" settings was misconfigured. Now it should be ok.