### PR TITLE
Always print time & count summary

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -116,16 +116,14 @@ class Printer
             $this->printUnusedIgnores($unusedIgnores);
         }
 
-        if ($hasError) {
-            return 255;
+        if (!$hasError) {
+            $this->printLine('');
+            $this->printLine('<green>No composer issues found</green>');
         }
 
-        $elapsed = round($result->getElapsedTime(), 3);
-        $this->printLine('');
-        $this->printLine('<green>No composer issues found</green>');
-        $this->printLine("<gray>(scanned</gray> {$result->getScannedFilesCount()} <gray>files in</gray> {$elapsed} <gray>s)</gray>" . PHP_EOL);
+        $this->printRunSummary($result);
 
-        return 0;
+        return $hasError ? 255 : 0;
     }
 
     /**
@@ -299,6 +297,12 @@ class Printer
         if ($package !== null && $path !== null) {
             $this->printLine(" • <gray>Error</gray> '{$unusedIgnore->getErrorType()}' <gray>was ignored for package</gray> '{$package}' <gray> and path</gray> '{$this->relativizePath($path)}', <gray>but it was never applied.</gray>");
         }
+    }
+
+    private function printRunSummary(AnalysisResult $result): void
+    {
+        $elapsed = round($result->getElapsedTime(), 3);
+        $this->printLine("<gray>(scanned</gray> {$result->getScannedFilesCount()} <gray>files in</gray> {$elapsed} <gray>s)</gray>" . PHP_EOL);
     }
 
 }

--- a/tests/PrinterTest.php
+++ b/tests/PrinterTest.php
@@ -53,6 +53,8 @@ OUT;
 Some ignored issues never occurred:
  • Error 'shadow-dependency' was globally ignored, but it was never applied.
 
+(scanned 2 files in 0.123 s)
+
 
 OUT;
 
@@ -132,6 +134,8 @@ Found unused dependencies!
 
   • dead/package
 
+(scanned 10 files in 0.123 s)
+
 
 OUT;
         $expectedVerboseOutput = <<<'OUT'
@@ -181,6 +185,8 @@ Found unused dependencies!
 (those are listed in composer.json, but no usage was found in scanned paths)
 
   • dead/package
+
+(scanned 10 files in 0.123 s)
 
 
 OUT;


### PR DESCRIPTION
This helps spotting any misconfiguration (scanning too many / too little files).