### PR TITLE
Optimize UsedSymbolExtractor performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It detects **shadowed composer dependencies** and **unused composer dependencies
 |-------------------------------------------|---------------------|------------------------|--------------------------|-------------------------------|------------|
 | maglnet/composer-require-checker          | ❌                   | ✅                     | ❌                         |  ❌                             | 124 secs   |
 | icanhazstring/composer-unused             | ✅                   | ❌                     | ❌                         |  ❌                             | 72 secs    |
-| **shipmonk/composer-dependency-analyser** | ✅                   | ✅                     | ✅                         |  ✅                             | **3 secs** |
+| **shipmonk/composer-dependency-analyser** | ✅                   | ✅                     | ✅                         |  ✅                             | **2 secs** |
 
 <sup><sub>\*Time measured on codebase with ~13 000 files</sub></sup>
 

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -82,30 +82,31 @@ class UsedSymbolExtractor
                 continue;
             }
 
+            $tokenType = $token[0];
             $tokenLine = $token[2];
 
-            if ($token[0] === T_USE) {
+            if ($tokenType === T_USE) {
                 $usedClass = $this->parseUseStatement();
 
                 if ($usedClass !== null) {
                     $useStatements = array_merge($useStatements, $usedClass);
                 }
             } elseif (PHP_VERSION_ID >= 80000) {
-                if ($token[0] === T_NAMESPACE) {
+                if ($tokenType === T_NAMESPACE) {
                     $useStatements = []; // reset use statements on namespace change
 
-                } elseif ($token[0] === T_NAME_FULLY_QUALIFIED) {
+                } elseif ($tokenType === T_NAME_FULLY_QUALIFIED) {
                     $symbolName = $this->normalizeBackslash($token[1]);
                     $usedSymbols[$symbolName][] = $tokenLine;
 
-                } elseif ($token[0] === T_NAME_QUALIFIED) {
+                } elseif ($tokenType === T_NAME_QUALIFIED) {
                     [$neededAlias] = explode('\\', $token[1], 2);
 
                     if (isset($useStatements[$neededAlias])) {
                         $symbolName = $this->normalizeBackslash($useStatements[$neededAlias] . substr($token[1], strlen($neededAlias)));
                         $usedSymbols[$symbolName][] = $tokenLine;
                     }
-                } elseif ($token[0] === T_STRING) {
+                } elseif ($tokenType === T_STRING) {
                     $name = $token[1];
 
                     if (isset($useStatements[$name])) {
@@ -114,20 +115,20 @@ class UsedSymbolExtractor
                     }
                 }
             } else {
-                if ($token[0] === T_NAMESPACE) {
+                if ($tokenType === T_NAMESPACE) {
                     $this->pointer++;
                     $nextName = $this->parseNameForOldPhp();
 
                     if (substr($nextName, 0, 1) !== '\\') { // not a namespace-relative name, but a new namespace declaration
                         $useStatements = []; // reset use statements on namespace change
                     }
-                } elseif ($token[0] === T_NS_SEPARATOR) { // fully qualified name
+                } elseif ($tokenType === T_NS_SEPARATOR) { // fully qualified name
                     $symbolName = $this->normalizeBackslash($this->parseNameForOldPhp());
 
                     if ($symbolName !== '') { // e.g. \array (NS separator followed by not-a-name)
                         $usedSymbols[$symbolName][] = $tokenLine;
                     }
-                } elseif ($token[0] === T_STRING) {
+                } elseif ($tokenType === T_STRING) {
                     $name = $this->parseNameForOldPhp();
 
                     if (isset($useStatements[$name])) { // unqualified name

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -78,7 +78,11 @@ class UsedSymbolExtractor
         $useStatements = [];
 
         while ($token = $this->getNextEffectiveToken()) {
-            $tokenLine = is_array($token) ? $token[2] : 0;
+            if (!is_array($token)) {
+                continue;
+            }
+
+            $tokenLine = $token[2];
 
             if ($token[0] === T_USE) {
                 $usedClass = $this->parseUseStatement();

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -2,7 +2,6 @@
 
 namespace ShipMonk\ComposerDependencyAnalyser;
 
-use function array_merge;
 use function count;
 use function explode;
 use function is_array;
@@ -86,10 +85,8 @@ class UsedSymbolExtractor
             $tokenLine = $token[2];
 
             if ($tokenType === T_USE) {
-                $usedClass = $this->parseUseStatement();
-
-                if ($usedClass !== null) {
-                    $useStatements = array_merge($useStatements, $usedClass);
+                foreach ($this->parseUseStatement() as $alias => $class) {
+                    $useStatements[$alias] = $class;
                 }
             } elseif (PHP_VERSION_ID >= 80000) {
                 if ($tokenType === T_NAMESPACE) {
@@ -209,12 +206,12 @@ class UsedSymbolExtractor
     }
 
     /**
-     * @return array<string, string>|null
+     * @return array<string, string>
      */
-    public function parseUseStatement(): ?array
+    public function parseUseStatement(): array
     {
         if ($this->inClassLevel !== null) {
-            return null;
+            return [];
         }
 
         $groupRoot = '';
@@ -261,7 +258,7 @@ class UsedSymbolExtractor
             }
         }
 
-        return $statements === [] ? null : $statements;
+        return $statements;
     }
 
     private function normalizeBackslash(string $class): string

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -76,8 +76,11 @@ class UsedSymbolExtractor
         $usedSymbols = [];
         $useStatements = [];
 
-        while ($this->pointer < $this->numTokens) {
-            $token = $this->tokens[$this->pointer++];
+        $numTokens = $this->numTokens;
+        $tokens = $this->tokens;
+
+        while ($this->pointer < $numTokens) {
+            $token = $tokens[$this->pointer++];
 
             if (is_array($token)) {
                 $tokenType = $token[0];

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -86,7 +86,7 @@ class UsedSymbolExtractor
 
             if ($tokenType === T_USE) {
                 foreach ($this->parseUseStatement() as $alias => $class) {
-                    $useStatements[$alias] = $class;
+                    $useStatements[$alias] = $this->normalizeBackslash($class);
                 }
             } elseif (PHP_VERSION_ID >= 80000) {
                 if ($tokenType === T_NAMESPACE) {
@@ -100,14 +100,14 @@ class UsedSymbolExtractor
                     [$neededAlias] = explode('\\', $token[1], 2);
 
                     if (isset($useStatements[$neededAlias])) {
-                        $symbolName = $this->normalizeBackslash($useStatements[$neededAlias] . substr($token[1], strlen($neededAlias)));
+                        $symbolName = $useStatements[$neededAlias] . substr($token[1], strlen($neededAlias));
                         $usedSymbols[$symbolName][] = $tokenLine;
                     }
                 } elseif ($tokenType === T_STRING) {
                     $name = $token[1];
 
                     if (isset($useStatements[$name])) {
-                        $symbolName = $this->normalizeBackslash($useStatements[$name]);
+                        $symbolName = $useStatements[$name];
                         $usedSymbols[$symbolName][] = $tokenLine;
                     }
                 }
@@ -129,14 +129,14 @@ class UsedSymbolExtractor
                     $name = $this->parseNameForOldPhp();
 
                     if (isset($useStatements[$name])) { // unqualified name
-                        $symbolName = $this->normalizeBackslash($useStatements[$name]);
+                        $symbolName = $useStatements[$name];
                         $usedSymbols[$symbolName][] = $tokenLine;
 
                     } else {
                         [$neededAlias] = explode('\\', $name, 2);
 
                         if (isset($useStatements[$neededAlias])) { // qualified name
-                            $symbolName = $this->normalizeBackslash($useStatements[$neededAlias] . substr($name, strlen($neededAlias)));
+                            $symbolName = $useStatements[$neededAlias] . substr($name, strlen($neededAlias));
                             $usedSymbols[$symbolName][] = $tokenLine;
                         }
                     }

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -160,19 +160,20 @@ class UsedSymbolExtractor
      */
     private function getNextEffectiveToken()
     {
-        for ($i = $this->pointer; $i < $this->numTokens; $i++) {
-            $this->pointer++;
-            $token = $this->tokens[$i];
+        while ($this->pointer < $this->numTokens) {
+            $token = $this->tokens[$this->pointer++];
 
-            if ($this->isNonEffectiveToken($token)) {
-                continue;
-            }
+            if (is_array($token)) {
+                $tokenType = $token[0];
 
-            if ($token[0] === T_CLASS || $token[0] === T_INTERFACE || $token[0] === T_TRAIT || (PHP_VERSION_ID >= 80100 && $token[0] === T_ENUM)) {
-                $this->inClassLevel = $this->level + 1;
-            }
+                if ($tokenType === T_WHITESPACE || $tokenType === T_COMMENT || $tokenType === T_DOC_COMMENT) {
+                    continue;
+                }
 
-            if ($token === '{') {
+                if ($tokenType === T_CLASS || $tokenType === T_INTERFACE || $tokenType === T_TRAIT || (PHP_VERSION_ID >= 80100 && $tokenType === T_ENUM)) {
+                    $this->inClassLevel = $this->level + 1;
+                }
+            } elseif ($token === '{') {
                 $this->level++;
             } elseif ($token === '}') {
                 if ($this->level === $this->inClassLevel) {
@@ -186,20 +187,6 @@ class UsedSymbolExtractor
         }
 
         return null;
-    }
-
-    /**
-     * @param array{int, string, int}|string $token
-     */
-    private function isNonEffectiveToken($token): bool
-    {
-        if (!is_array($token)) {
-            return false;
-        }
-
-        return $token[0] === T_WHITESPACE ||
-            $token[0] === T_COMMENT ||
-            $token[0] === T_DOC_COMMENT;
     }
 
     /**

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -179,47 +179,22 @@ class UsedSymbolExtractor
     }
 
     /**
-     * @return array{int, string, int}|string|null The token if exists, null otherwise.
-     */
-    private function getNextEffectiveToken()
-    {
-        while ($this->pointer < $this->numTokens) {
-            $token = $this->tokens[$this->pointer++];
-
-            if (is_array($token)) {
-                $tokenType = $token[0];
-
-                if ($tokenType === T_WHITESPACE || $tokenType === T_COMMENT || $tokenType === T_DOC_COMMENT) {
-                    continue;
-                }
-            }
-
-            return $token;
-        }
-
-        return null;
-    }
-
-    /**
      * See old behaviour: https://wiki.php.net/rfc/namespaced_names_as_token
      */
     private function parseNameForOldPhp(): string
     {
         $this->pointer--; // we already detected start token above
-
         $name = '';
 
-        do {
-            $token = $this->getNextEffectiveToken();
-            $isNamePart = is_array($token) && ($token[0] === T_STRING || $token[0] === T_NS_SEPARATOR);
+        while ($this->pointer < $this->numTokens) {
+            $token = $this->tokens[$this->pointer++];
 
-            if (!$isNamePart) {
+            if (!is_array($token) || ($token[0] !== T_STRING && $token[0] !== T_NS_SEPARATOR)) {
                 break;
             }
 
             $name .= $token[1];
-
-        } while (true);
+        }
 
         return $name;
     }

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -83,10 +83,7 @@ class UsedSymbolExtractor
             $token = $tokens[$this->pointer++];
 
             if (is_array($token)) {
-                $tokenType = $token[0];
-                $tokenLine = $token[2];
-
-                switch ($tokenType) {
+                switch ($token[0]) {
                     case T_CLASS:
                     case T_INTERFACE:
                     case T_TRAIT:
@@ -107,7 +104,7 @@ class UsedSymbolExtractor
 
                     case PHP_VERSION_ID >= 80000 ? T_NAME_FULLY_QUALIFIED : -1:
                         $symbolName = $this->normalizeBackslash($token[1]);
-                        $usedSymbols[$symbolName][] = $tokenLine;
+                        $usedSymbols[$symbolName][] = $token[2];
                         break;
 
                     case PHP_VERSION_ID >= 80000 ? T_NAME_QUALIFIED : -1:
@@ -115,7 +112,7 @@ class UsedSymbolExtractor
 
                         if (isset($useStatements[$neededAlias])) {
                             $symbolName = $useStatements[$neededAlias] . substr($token[1], strlen($neededAlias));
-                            $usedSymbols[$symbolName][] = $tokenLine;
+                            $usedSymbols[$symbolName][] = $token[2];
                         }
 
                         break;
@@ -125,7 +122,7 @@ class UsedSymbolExtractor
 
                         if (isset($useStatements[$name])) {
                             $symbolName = $useStatements[$name];
-                            $usedSymbols[$symbolName][] = $tokenLine;
+                            $usedSymbols[$symbolName][] = $token[2];
                         }
 
                         break;
@@ -144,7 +141,7 @@ class UsedSymbolExtractor
                         $symbolName = $this->normalizeBackslash($this->parseNameForOldPhp());
 
                         if ($symbolName !== '') { // e.g. \array (NS separator followed by not-a-name)
-                            $usedSymbols[$symbolName][] = $tokenLine;
+                            $usedSymbols[$symbolName][] = $token[2];
                         }
 
                         break;
@@ -154,14 +151,14 @@ class UsedSymbolExtractor
 
                         if (isset($useStatements[$name])) { // unqualified name
                             $symbolName = $useStatements[$name];
-                            $usedSymbols[$symbolName][] = $tokenLine;
+                            $usedSymbols[$symbolName][] = $token[2];
 
                         } else {
                             [$neededAlias] = explode('\\', $name, 2);
 
                             if (isset($useStatements[$neededAlias])) { // qualified name
                                 $symbolName = $useStatements[$neededAlias] . substr($name, strlen($neededAlias));
-                                $usedSymbols[$symbolName][] = $tokenLine;
+                                $usedSymbols[$symbolName][] = $token[2];
                             }
                         }
 

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -86,28 +86,22 @@ class UsedSymbolExtractor
                 if ($usedClass !== null) {
                     $useStatements = array_merge($useStatements, $usedClass);
                 }
-            }
-
-            if (PHP_VERSION_ID >= 80000) {
+            } elseif (PHP_VERSION_ID >= 80000) {
                 if ($token[0] === T_NAMESPACE) {
                     $useStatements = []; // reset use statements on namespace change
-                }
 
-                if ($token[0] === T_NAME_FULLY_QUALIFIED) {
+                } elseif ($token[0] === T_NAME_FULLY_QUALIFIED) {
                     $symbolName = $this->normalizeBackslash($token[1]);
                     $usedSymbols[$symbolName][] = $tokenLine;
-                }
 
-                if ($token[0] === T_NAME_QUALIFIED) {
+                } elseif ($token[0] === T_NAME_QUALIFIED) {
                     [$neededAlias] = explode('\\', $token[1], 2);
 
                     if (isset($useStatements[$neededAlias])) {
                         $symbolName = $this->normalizeBackslash($useStatements[$neededAlias] . substr($token[1], strlen($neededAlias)));
                         $usedSymbols[$symbolName][] = $tokenLine;
                     }
-                }
-
-                if ($token[0] === T_STRING) {
+                } elseif ($token[0] === T_STRING) {
                     $name = $token[1];
 
                     if (isset($useStatements[$name])) {
@@ -123,17 +117,13 @@ class UsedSymbolExtractor
                     if (substr($nextName, 0, 1) !== '\\') { // not a namespace-relative name, but a new namespace declaration
                         $useStatements = []; // reset use statements on namespace change
                     }
-                }
-
-                if ($token[0] === T_NS_SEPARATOR) { // fully qualified name
+                } elseif ($token[0] === T_NS_SEPARATOR) { // fully qualified name
                     $symbolName = $this->normalizeBackslash($this->parseNameForOldPhp());
 
                     if ($symbolName !== '') { // e.g. \array (NS separator followed by not-a-name)
                         $usedSymbols[$symbolName][] = $tokenLine;
                     }
-                }
-
-                if ($token[0] === T_STRING) {
+                } elseif ($token[0] === T_STRING) {
                     $name = $this->parseNameForOldPhp();
 
                     if (isset($useStatements[$name])) { // unqualified name


### PR DESCRIPTION
Before

```
vendor/bin/composer-dependency-analyser --config composer-dependency-analyser.php
  Time (mean ± σ):      2.218 s ±  0.012 s    [User: 2.103 s, System: 0.114 s]
  Range (min … max):    2.202 s …  2.235 s    10 runs
```

After

```
vendor/bin/composer-dependency-analyser --config composer-dependency-analyser.php
  Time (mean ± σ):      1.386 s ±  0.006 s    [User: 1.287 s, System: 0.097 s]
  Range (min … max):    1.375 s …  1.394 s    10 runs
```

