### PR TITLE
Fix edgecase where `use Trait` is treated as use statement

### DIFF
--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -13,7 +13,9 @@ use const PHP_VERSION_ID;
 use const T_AS;
 use const T_CLASS;
 use const T_COMMENT;
+use const T_CURLY_OPEN;
 use const T_DOC_COMMENT;
+use const T_DOLLAR_OPEN_CURLY_BRACES;
 use const T_ENUM;
 use const T_INTERFACE;
 use const T_NAME_FULLY_QUALIFIED;
@@ -155,6 +157,11 @@ class UsedSymbolExtractor
                             }
                         }
 
+                        break;
+
+                    case T_CURLY_OPEN:
+                    case T_DOLLAR_OPEN_CURLY_BRACES:
+                        $level++;
                         break;
                 }
             } elseif ($token === '{') {

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -81,6 +81,11 @@ class UsedSymbolExtractorTest extends TestCase
                 'DateTimeImmutable' => [3],
             ]
         ];
+
+        yield 'curly braces' => [
+            __DIR__ . '/data/not-autoloaded/used-symbols/curly-braces.php',
+            []
+        ];
     }
 
 }

--- a/tests/data/not-autoloaded/used-symbols/curly-braces.php
+++ b/tests/data/not-autoloaded/used-symbols/curly-braces.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Curly;
+
+trait MyTrait {}
+
+class Foo {
+
+    public function foo($foo): void
+    {
+        echo "${$foo}";
+    }
+
+    use MyTrait; // not a use statement, $level should not be 0 here
+
+}
+
+echo MyTrait::class;


### PR DESCRIPTION
Variable `$level` should be 0 at the end of file (for valid php files).