### PR TITLE
Autoload only vendor of given composer.json

### DIFF
--- a/bin/composer-dependency-analyser
+++ b/bin/composer-dependency-analyser
@@ -39,15 +39,11 @@ Ignore options:
 
 EOD;
 
-$autoloadFiles = [
-    __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/../../../autoload.php',
-];
-
-foreach ($autoloadFiles as $autoloadFile) {
-    if (file_exists($autoloadFile)) {
-        require_once $autoloadFile;
-        break;
+// preload own classes (do not rely on presence in composer's autoloader)
+foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator(__DIR__ . '/../src')) as $entry) {
+    /** @var DirectoryIterator $entry */
+    if ($entry->isFile() && $entry->getExtension() === 'php') {
+        require_once $entry->getPathname();
     }
 }
 
@@ -80,6 +76,24 @@ try {
 if (isset($providedOptions['help'])) {
     echo $usage;
     exit;
+}
+
+$composerJsonPath = isset($providedOptions['composer-json'])
+    ? ($cwd . "/" . $providedOptions['composer-json'])
+    : ($cwd . "/composer.json");
+
+try {
+    $composerJson = new ComposerJson($composerJsonPath);
+} catch (OurRuntimeException $e) {
+    $exit($e->getMessage());
+}
+
+// load vendor that belongs to given composer.json
+$autoloadFile = dirname($composerJsonPath) . '/' . $composerJson->vendorDir . '/autoload.php';
+if (is_file($autoloadFile)) {
+    require_once $autoloadFile;
+} else {
+    $exit("Cannot find composer's autoload file, expected at '$autoloadFile'");
 }
 
 if (isset($providedOptions['config'])) {
@@ -128,16 +142,6 @@ if ($ignoreDevInProd) {
 }
 if ($ignoreProdOnlyInDev) {
     $config->ignoreErrors([ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV]);
-}
-
-$composerJsonPath = isset($providedOptions['composer-json'])
-    ? ($cwd . "/" . $providedOptions['composer-json'])
-    : ($cwd . "/composer.json");
-
-try {
-    $composerJson = new ComposerJson($composerJsonPath);
-} catch (OurRuntimeException $e) {
-    $exit($e->getMessage());
 }
 
 $loaders = ClassLoader::getRegisteredLoaders();

--- a/bin/composer-dependency-analyser
+++ b/bin/composer-dependency-analyser
@@ -93,7 +93,7 @@ try {
 }
 
 // load vendor that belongs to given composer.json
-$autoloadFile = dirname($composerJsonPath) . '/' . $composerJson->vendorDir . '/autoload.php';
+$autoloadFile = $composerJson->composerAutoloadPath;
 if (is_file($autoloadFile)) {
     require_once $autoloadFile;
 } else {

--- a/bin/composer-dependency-analyser
+++ b/bin/composer-dependency-analyser
@@ -39,13 +39,17 @@ Ignore options:
 
 EOD;
 
-// preload own classes (do not rely on presence in composer's autoloader)
-foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator(__DIR__ . '/../src')) as $entry) {
-    /** @var DirectoryIterator $entry */
-    if ($entry->isFile() && $entry->getExtension() === 'php') {
-        require_once $entry->getPathname();
+$psr4Prefix = 'ShipMonk\\ComposerDependencyAnalyser\\';
+
+// autoloader for own classes (do not rely on presence in composer's autoloader)
+spl_autoload_register(static function (string $class) use ($psr4Prefix): void {
+    if (strpos($class, $psr4Prefix) === 0) {
+        /** @var string $classWithoutPrefix */
+        $classWithoutPrefix = substr($class, strlen($psr4Prefix));
+        $file = __DIR__ . '/../src/' . str_replace('\\', '/', $classWithoutPrefix) . '.php';
+        require $file;
     }
-}
+});
 
 $cwd = getcwd();
 $printer = new Printer($cwd === false ? '' : $cwd);

--- a/src/ComposerJson.php
+++ b/src/ComposerJson.php
@@ -27,6 +27,12 @@ class ComposerJson
 {
 
     /**
+     * @readonly
+     * @var string
+     */
+    public $vendorDir;
+
+    /**
      * Package => isDev
      *
      * @readonly
@@ -51,6 +57,7 @@ class ComposerJson
         $basePath = dirname($composerJsonPath);
 
         $composerJsonData = $this->parseComposerJson($composerJsonPath);
+        $this->vendorDir = $composerJsonData['vendor-dir'] ?? 'vendor';
 
         $requiredPackages = $composerJsonData['require'] ?? [];
         $requiredDevPackages = $composerJsonData['require-dev'] ?? [];
@@ -140,6 +147,7 @@ class ComposerJson
      * @return array{
      *     require?: array<string, string>,
      *     require-dev?: array<string, string>,
+     *     vendor-dir?: string,
      *     autoload?: array{
      *          psr-0?: array<string, string|string[]>,
      *          psr-4?: array<string, string|string[]>,

--- a/tests/data/not-autoloaded/composer/sample.json
+++ b/tests/data/not-autoloaded/composer/sample.json
@@ -13,5 +13,8 @@
         "files": [
             "dir2/file1.php"
         ]
+    },
+    "config": {
+        "vendor-dir": "custom-vendor/"
     }
 }


### PR DESCRIPTION
- Resolves #92. 
- This should allow scanning codebases located outside of installed location, composer global installation and e.g. usage of [bamarni/composer-bin-plugin](https://github.com/bamarni/composer-bin-plugin)