### PR TITLE
Analyse even php extension dependencies (`ext-*`)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -142,6 +142,11 @@ jobs:
                 run: composer install --no-progress --no-interaction --ignore-platform-reqs ${{ matrix.composerArgs }}
 
             -
+                name: Run analyser (--disable-ext-analysis)
+                working-directory: ${{ matrix.repo }}
+                run: php ../../analyser/bin/composer-dependency-analyser --show-all-usages --disable-ext-analysis ${{ matrix.cdaArgs }}
+
+            -
                 name: Run analyser
                 working-directory: ${{ matrix.repo }}
                 run: php ../../analyser/bin/composer-dependency-analyser --show-all-usages ${{ matrix.cdaArgs }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,6 +119,11 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: 8.3
+                    ini-file: development
+
+            -
+                name: List enabled extensions
+                run: php -m
 
             -
                 name: Install analyser dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -144,4 +144,4 @@ jobs:
             -
                 name: Run analyser
                 working-directory: ${{ matrix.repo }}
-                run: php ../../analyser/bin/composer-dependency-analyser ${{ matrix.cdaArgs }}
+                run: php ../../analyser/bin/composer-dependency-analyser --show-all-usages ${{ matrix.cdaArgs }}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This tool reads your `composer.json` and scans all paths listed in `autoload` & 
 - `--verbose` to see more example classes & usages
 - `--show-all-usages` to see all usages
 - `--format` to use different output format, available are: `console` (default), `junit`
+- `--disable-ext-analysis` to disable php extensions analysis (e.g. `ext-xml`)
 - `--ignore-unknown-classes` to globally ignore unknown classes
 - `--ignore-unknown-functions` to globally ignore unknown functions
 - `--ignore-shadow-deps` to globally ignore shadow dependencies
@@ -128,6 +129,7 @@ return $config
     //// Adjust analysis
     ->enableAnalysisOfUnusedDevDependencies() // dev packages are often used only in CI, so this is not enabled by default
     ->disableReportingUnmatchedIgnores() // do not report ignores that never matched any error
+    ->disableExtensionsAnalysis() // do not analyse ext-* dependencies
 
     //// Use symbols from yaml/xml/neon files
     // - designed for DIC config files (see below)

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ NO_COLOR=1 vendor/bin/composer-dependency-analyser
 ```
 
 ## Limitations:
-- Extension dependencies are not analysed (e.g. `ext-json`)
+- For precise `ext-x` analysis, your enabled extentions of your php runtime should be superset of those used in the scanned project
 
 ## Contributing:
 - Check your code by `composer check`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Found unused dependencies!
 ```
 
 ## Detected issues:
-This tool reads your `composer.json` and scans all paths listed in `autoload` & `autoload-dev` sections while analysing:
+This tool reads your `composer.json` and scans all paths listed in `autoload` & `autoload-dev` sections while analysing you dependencies (both **packages and PHP extensions**).
 
 ### Shadowed dependencies
   - Those are dependencies of your dependencies, which are not listed in `composer.json`
@@ -168,8 +168,8 @@ Another approach for DIC-only usages is to scan the generated php file, but that
 NO_COLOR=1 vendor/bin/composer-dependency-analyser
 ```
 
-## Limitations:
-- For precise `ext-x` analysis, your enabled extentions of your php runtime should be superset of those used in the scanned project
+## Recommendations:
+- For precise `ext-*` analysis, your enabled extensions of your php runtime should be superset of those used in the scanned project
 
 ## Contributing:
 - Check your code by `composer check`

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,9 +1,14 @@
 <?php declare(strict_types = 1);
 
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
 return (new Configuration())
-    ->disableExtensionsAnalysis()
     ->addPathToScan(__FILE__, true)
     ->addPathToScan(__DIR__ . '/bin', false)
-    ->addPathToExclude(__DIR__ . '/tests/data');
+    ->addPathToExclude(__DIR__ . '/tests/data')
+    ->ignoreErrorsOnExtensionsAndPaths(
+        ['ext-dom', 'ext-libxml'],
+        [__DIR__ . '/src/Result/JunitFormatter.php'], // optional usages guarded with extension_loaded()
+        [ErrorType::DEV_DEPENDENCY_IN_PROD]
+    );

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -3,6 +3,7 @@
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 
 return (new Configuration())
+    ->disableExtensionsAnalysis()
     ->addPathToScan(__FILE__, true)
     ->addPathToScan(__DIR__ . '/bin', false)
     ->addPathToExclude(__DIR__ . '/tests/data');

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -119,6 +119,13 @@ class Analyser
     private $extensionSymbols;
 
     /**
+     * lowercase symbol name => kind
+     *
+     * @var array<string, SymbolKind::*>
+     */
+    private $extensionSymbolKinds;
+
+    /**
      * @param array<string, ClassLoader> $classLoaders vendorDir => ClassLoader (e.g. result of \Composer\Autoload\ClassLoader::getRegisteredLoaders())
      * @param array<string, bool> $composerJsonDependencies package or ext-* => is dev dependency
      */
@@ -385,9 +392,7 @@ class Analyser
         }
 
         return (new UsedSymbolExtractor($code))->parseUsedSymbols(
-            array_keys($this->extensionSymbols[SymbolKind::CLASSLIKE]),
-            array_keys($this->extensionSymbols[SymbolKind::FUNCTION]),
-            array_keys($this->extensionSymbols[SymbolKind::CONSTANT])
+            $this->extensionSymbolKinds
         );
     }
 
@@ -547,6 +552,7 @@ class Analyser
                         $this->ignoredSymbols[$constantName] = true;
                     } else {
                         $this->extensionSymbols[SymbolKind::CONSTANT][$constantName] = $extensionName;
+                        $this->extensionSymbolKinds[strtolower($constantName)] = SymbolKind::CONSTANT;
                     }
                 }
             }
@@ -568,6 +574,7 @@ class Analyser
                         $this->ignoredSymbols[$functionName] = true;
                     } else {
                         $this->extensionSymbols[SymbolKind::FUNCTION][$functionName] = $extensionName;
+                        $this->extensionSymbolKinds[$functionName] = SymbolKind::FUNCTION;
                     }
                 }
             }
@@ -590,6 +597,7 @@ class Analyser
                         $this->ignoredSymbols[$classLikeName] = true;
                     } else {
                         $this->extensionSymbols[SymbolKind::CLASSLIKE][$classLikeName] = $extensionName;
+                        $this->extensionSymbolKinds[strtolower($classLikeName)] = SymbolKind::CLASSLIKE;
                     }
                 }
             }

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -162,7 +162,7 @@ class Analyser
         $unusedErrors = [];
 
         $usedDependencies = [];
-        $prodPackagesUsedInProdPath = [];
+        $prodDependenciesUsedInProdPath = [];
 
         $usages = [];
 
@@ -233,7 +233,7 @@ class Analyser
                         !$isDevFilePath
                         && !$this->isDevDependency($dependencyName)
                     ) {
-                        $prodPackagesUsedInProdPath[$dependencyName] = true;
+                        $prodDependenciesUsedInProdPath[$dependencyName] = true;
                     }
 
                     $usedDependencies[$dependencyName] = true;
@@ -300,7 +300,7 @@ class Analyser
         }));
         $prodPackagesUsedOnlyInDev = array_diff(
             $prodDependencies,
-            array_keys($prodPackagesUsedInProdPath),
+            array_keys($prodDependenciesUsedInProdPath),
             array_keys($forceUsedPackages), // we dont know where are those used, lets not report them
             $unusedDependencies,
             self::CORE_EXTENSIONS

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -535,6 +535,7 @@ class Analyser
 
         /** @var array<string, array<string, mixed>> $definedConstants */
         $definedConstants = get_defined_constants(true);
+
         foreach ($definedConstants as $constantExtension => $constants) {
             foreach ($constants as $constantName => $_) {
                 if ($constantExtension === 'user') {

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -175,14 +175,14 @@ class Analyser
 
             foreach ($usedSymbolsByKind as $kind => $usedSymbols) {
                 foreach ($usedSymbols as $usedSymbol => $lineNumbers) {
-                    $usedSymbolNameForIgnoreCheck = $kind === SymbolKind::FUNCTION ? strtolower($usedSymbol) : $usedSymbol;
+                    $normalizedUsedSymbolName = $kind === SymbolKind::FUNCTION ? strtolower($usedSymbol) : $usedSymbol;
 
-                    if (isset($this->ignoredSymbols[$usedSymbolNameForIgnoreCheck])) {
+                    if (isset($this->ignoredSymbols[$normalizedUsedSymbolName])) {
                         continue;
                     }
 
-                    if (isset($this->extensionSymbols[$kind][$usedSymbol])) {
-                        $dependencyName = $this->extensionSymbols[$kind][$usedSymbol];
+                    if (isset($this->extensionSymbols[$kind][$normalizedUsedSymbolName])) {
+                        $dependencyName = $this->extensionSymbols[$kind][$normalizedUsedSymbolName];
 
                     } else {
                         $symbolPath = $this->getSymbolPath($usedSymbol, $kind);

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -20,6 +20,7 @@ class Cli
         'version' => false,
         'help' => false,
         'verbose' => false,
+        'disable-ext-analysis' => false,
         'ignore-shadow-deps' => false,
         'ignore-unused-deps' => false,
         'ignore-dev-in-prod-deps' => false,
@@ -151,6 +152,10 @@ class Cli
 
         if (isset($this->providedOptions['verbose'])) {
             $options->verbose = true;
+        }
+
+        if (isset($this->providedOptions['disable-ext-analysis'])) {
+            $options->disableExtAnalysis = true;
         }
 
         if (isset($this->providedOptions['ignore-shadow-deps'])) {

--- a/src/CliOptions.php
+++ b/src/CliOptions.php
@@ -23,6 +23,11 @@ class CliOptions
     /**
      * @var true|null
      */
+    public $disableExtAnalysis = null;
+
+    /**
+     * @var true|null
+     */
     public $ignoreShadowDeps = null;
 
     /**

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -72,12 +72,12 @@ class Configuration
     /**
      * @var array<string, list<ErrorType::*>>
      */
-    private $ignoredErrorsOnPackage = [];
+    private $ignoredErrorsOnDependency = [];
 
     /**
      * @var array<string, array<string, list<ErrorType::*>>>
      */
-    private $ignoredErrorsOnPackageAndPath = [];
+    private $ignoredErrorsOnDependencyAndPath = [];
 
     /**
      * @var list<string>
@@ -296,11 +296,32 @@ class Configuration
     public function ignoreErrorsOnPackage(string $packageName, array $errorTypes): self
     {
         $this->checkPackageName($packageName);
+        $this->ignoreErrorsOnDependency($packageName, $errorTypes);
+        return $this;
+    }
+
+    /**
+     * @param list<ErrorType::*> $errorTypes
+     * @return $this
+     * @throws InvalidConfigException
+     */
+    public function ignoreErrorsOnExtension(string $extension, array $errorTypes): self
+    {
+        $this->checkExtensionName($extension);
+        $this->ignoreErrorsOnDependency($extension, $errorTypes);
+        return $this;
+    }
+
+    /**
+     * @param list<ErrorType::*> $errorTypes
+     * @throws InvalidConfigException
+     */
+    private function ignoreErrorsOnDependency(string $dependency, array $errorTypes): void
+    {
         $this->checkAllowedErrorTypeForPackageIgnore($errorTypes);
 
-        $previousErrorTypes = $this->ignoredErrorsOnPackage[$packageName] ?? [];
-        $this->ignoredErrorsOnPackage[$packageName] = array_merge($previousErrorTypes, $errorTypes);
-        return $this;
+        $previousErrorTypes = $this->ignoredErrorsOnDependency[$dependency] ?? [];
+        $this->ignoredErrorsOnDependency[$dependency] = array_merge($previousErrorTypes, $errorTypes);
     }
 
     /**
@@ -319,6 +340,21 @@ class Configuration
     }
 
     /**
+     * @param list<string> $extensions
+     * @param list<ErrorType::*> $errorTypes
+     * @return $this
+     * @throws InvalidConfigException
+     */
+    public function ignoreErrorsOnExtensions(array $extensions, array $errorTypes): self
+    {
+        foreach ($extensions as $extension) {
+            $this->ignoreErrorsOnExtension($extension, $errorTypes);
+        }
+
+        return $this;
+    }
+
+    /**
      * @param list<ErrorType::*> $errorTypes
      * @return $this
      * @throws InvalidPathException
@@ -327,14 +363,37 @@ class Configuration
     public function ignoreErrorsOnPackageAndPath(string $packageName, string $path, array $errorTypes): self
     {
         $this->checkPackageName($packageName);
+        $this->ignoreErrorsOnDependencyAndPath($packageName, $path, $errorTypes);
+        return $this;
+    }
+
+    /**
+     * @param list<ErrorType::*> $errorTypes
+     * @return $this
+     * @throws InvalidPathException
+     * @throws InvalidConfigException
+     */
+    public function ignoreErrorsOnExtensionAndPath(string $extension, string $path, array $errorTypes): self
+    {
+        $this->checkExtensionName($extension);
+        $this->ignoreErrorsOnDependencyAndPath($extension, $path, $errorTypes);
+        return $this;
+    }
+
+    /**
+     * @param list<ErrorType::*> $errorTypes
+     * @throws InvalidPathException
+     * @throws InvalidConfigException
+     */
+    private function ignoreErrorsOnDependencyAndPath(string $dependency, string $path, array $errorTypes): void
+    {
         $this->checkAllowedErrorTypeForPathIgnore($errorTypes);
         $this->checkAllowedErrorTypeForPackageIgnore($errorTypes);
 
         $realpath = Path::realpath($path);
 
-        $previousErrorTypes = $this->ignoredErrorsOnPackageAndPath[$packageName][$realpath] ?? [];
-        $this->ignoredErrorsOnPackageAndPath[$packageName][$realpath] = array_merge($previousErrorTypes, $errorTypes);
-        return $this;
+        $previousErrorTypes = $this->ignoredErrorsOnDependencyAndPath[$dependency][$realpath] ?? [];
+        $this->ignoredErrorsOnDependencyAndPath[$dependency][$realpath] = array_merge($previousErrorTypes, $errorTypes);
     }
 
     /**
@@ -354,6 +413,22 @@ class Configuration
     }
 
     /**
+     * @param list<string> $paths
+     * @param list<ErrorType::*> $errorTypes
+     * @return $this
+     * @throws InvalidPathException
+     * @throws InvalidConfigException
+     */
+    public function ignoreErrorsOnExtensionAndPaths(string $extension, array $paths, array $errorTypes): self
+    {
+        foreach ($paths as $path) {
+            $this->ignoreErrorsOnExtensionAndPath($extension, $path, $errorTypes);
+        }
+
+        return $this;
+    }
+
+    /**
      * @param list<string> $packages
      * @param list<string> $paths
      * @param list<ErrorType::*> $errorTypes
@@ -365,6 +440,23 @@ class Configuration
     {
         foreach ($packages as $package) {
             $this->ignoreErrorsOnPackageAndPaths($package, $paths, $errorTypes);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param list<string> $extensions
+     * @param list<string> $paths
+     * @param list<ErrorType::*> $errorTypes
+     * @return $this
+     * @throws InvalidPathException
+     * @throws InvalidConfigException
+     */
+    public function ignoreErrorsOnExtensionsAndPaths(array $extensions, array $paths, array $errorTypes): self
+    {
+        foreach ($extensions as $extension) {
+            $this->ignoreErrorsOnExtensionAndPaths($extension, $paths, $errorTypes);
         }
 
         return $this;
@@ -425,8 +517,8 @@ class Configuration
         return new IgnoreList(
             $this->ignoredErrors,
             $this->ignoredErrorsOnPath,
-            $this->ignoredErrorsOnPackage,
-            $this->ignoredErrorsOnPackageAndPath,
+            $this->ignoredErrorsOnDependency,
+            $this->ignoredErrorsOnDependencyAndPath,
             $this->ignoredUnknownClasses,
             $this->ignoredUnknownClassesRegexes,
             $this->ignoredUnknownFunctions,
@@ -498,6 +590,16 @@ class Configuration
     private function isFilepathWithinPath(string $filePath, string $path): bool
     {
         return strpos($filePath, $path) === 0;
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    private function checkExtensionName(string $extension): void
+    {
+        if (strpos($extension, 'ext-') !== 0) {
+            throw new InvalidConfigException("Invalid php extension dependency name '$extension', it is expected to start with ext-");
+        }
     }
 
     /**

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -17,6 +17,11 @@ class Configuration
     /**
      * @var bool
      */
+    private $extensionsAnalysis = true;
+
+    /**
+     * @var bool
+     */
     private $scanComposerAutoloadPaths = true;
 
     /**
@@ -95,6 +100,17 @@ class Configuration
     private $ignoredUnknownFunctionsRegexes = [];
 
     /**
+     * Disable analysis of ext-* dependencies
+     *
+     * @return $this
+     */
+    public function disableExtensionsAnalysis(): self
+    {
+        $this->extensionsAnalysis = false;
+        return $this;
+    }
+
+    /**
      * @return $this
      */
     public function disableComposerAutoloadPathScan(): self
@@ -103,6 +119,9 @@ class Configuration
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function disableReportingUnmatchedIgnores(): self
     {
         $this->reportUnmatchedIgnores = false;
@@ -437,6 +456,11 @@ class Configuration
     public function getPathsToScan(): array
     {
         return $this->pathsToScan;
+    }
+
+    public function shouldAnalyseExtensions(): bool
+    {
+        return $this->extensionsAnalysis;
     }
 
     public function shouldScanComposerAutoloadPaths(): bool

--- a/src/Config/Ignore/IgnoreList.php
+++ b/src/Config/Ignore/IgnoreList.php
@@ -25,12 +25,12 @@ class IgnoreList
     /**
      * @var array<string, array<ErrorType::*, bool>>
      */
-    private $ignoredErrorsOnPackage = [];
+    private $ignoredErrorsOnDependency = [];
 
     /**
      * @var array<string, array<string, array<ErrorType::*, bool>>>
      */
-    private $ignoredErrorsOnPackageAndPath = [];
+    private $ignoredErrorsOnDependencyAndPath = [];
 
     /**
      * @var array<string, bool>
@@ -55,8 +55,8 @@ class IgnoreList
     /**
      * @param list<ErrorType::*> $ignoredErrors
      * @param array<string, list<ErrorType::*>> $ignoredErrorsOnPath
-     * @param array<string, list<ErrorType::*>> $ignoredErrorsOnPackage
-     * @param array<string, array<string, list<ErrorType::*>>> $ignoredErrorsOnPackageAndPath
+     * @param array<string, list<ErrorType::*>> $ignoredErrorsOnDependency
+     * @param array<string, array<string, list<ErrorType::*>>> $ignoredErrorsOnDependencyAndPath
      * @param list<string> $ignoredUnknownClasses
      * @param list<string> $ignoredUnknownClassesRegexes
      * @param list<string> $ignoredUnknownFunctions
@@ -65,8 +65,8 @@ class IgnoreList
     public function __construct(
         array $ignoredErrors,
         array $ignoredErrorsOnPath,
-        array $ignoredErrorsOnPackage,
-        array $ignoredErrorsOnPackageAndPath,
+        array $ignoredErrorsOnDependency,
+        array $ignoredErrorsOnDependencyAndPath,
         array $ignoredUnknownClasses,
         array $ignoredUnknownClassesRegexes,
         array $ignoredUnknownFunctions,
@@ -79,13 +79,13 @@ class IgnoreList
             $this->ignoredErrorsOnPath[$path] = array_fill_keys($errorTypes, false);
         }
 
-        foreach ($ignoredErrorsOnPackage as $packageName => $errorTypes) {
-            $this->ignoredErrorsOnPackage[$packageName] = array_fill_keys($errorTypes, false);
+        foreach ($ignoredErrorsOnDependency as $dependency => $errorTypes) {
+            $this->ignoredErrorsOnDependency[$dependency] = array_fill_keys($errorTypes, false);
         }
 
-        foreach ($ignoredErrorsOnPackageAndPath as $packageName => $paths) {
+        foreach ($ignoredErrorsOnDependencyAndPath as $dependency => $paths) {
             foreach ($paths as $path => $errorTypes) {
-                $this->ignoredErrorsOnPackageAndPath[$packageName][$path] = array_fill_keys($errorTypes, false);
+                $this->ignoredErrorsOnDependencyAndPath[$dependency][$path] = array_fill_keys($errorTypes, false);
             }
         }
 
@@ -116,7 +116,7 @@ class IgnoreList
             }
         }
 
-        foreach ($this->ignoredErrorsOnPackage as $packageName => $errorTypes) {
+        foreach ($this->ignoredErrorsOnDependency as $packageName => $errorTypes) {
             foreach ($errorTypes as $errorType => $ignored) {
                 if (!$ignored) {
                     $unused[] = new UnusedErrorIgnore($errorType, null, $packageName);
@@ -124,7 +124,7 @@ class IgnoreList
             }
         }
 
-        foreach ($this->ignoredErrorsOnPackageAndPath as $packageName => $paths) {
+        foreach ($this->ignoredErrorsOnDependencyAndPath as $packageName => $paths) {
             foreach ($paths as $path => $errorTypes) {
                 foreach ($errorTypes as $errorType => $ignored) {
                     if (!$ignored) {
@@ -240,12 +240,12 @@ class IgnoreList
     /**
      * @param ErrorType::SHADOW_DEPENDENCY|ErrorType::UNUSED_DEPENDENCY|ErrorType::DEV_DEPENDENCY_IN_PROD|ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV $errorType
      */
-    public function shouldIgnoreError(string $errorType, ?string $realPath, ?string $packageName): bool
+    public function shouldIgnoreError(string $errorType, ?string $realPath, ?string $dependency): bool
     {
         $ignoredGlobally = $this->shouldIgnoreErrorGlobally($errorType);
         $ignoredByPath = $realPath !== null && $this->shouldIgnoreErrorOnPath($errorType, $realPath);
-        $ignoredByPackage = $packageName !== null && $this->shouldIgnoreErrorOnPackage($errorType, $packageName);
-        $ignoredByPackageAndPath = $realPath !== null && $packageName !== null && $this->shouldIgnoreErrorOnPackageAndPath($errorType, $packageName, $realPath);
+        $ignoredByPackage = $dependency !== null && $this->shouldIgnoreErrorOnDependency($errorType, $dependency);
+        $ignoredByPackageAndPath = $realPath !== null && $dependency !== null && $this->shouldIgnoreErrorOnDependencyAndPath($errorType, $dependency, $realPath);
 
         return $ignoredGlobally || $ignoredByPackageAndPath || $ignoredByPath || $ignoredByPackage;
     }
@@ -281,10 +281,10 @@ class IgnoreList
     /**
      * @param ErrorType::* $errorType
      */
-    private function shouldIgnoreErrorOnPackage(string $errorType, string $packageName): bool
+    private function shouldIgnoreErrorOnDependency(string $errorType, string $dependency): bool
     {
-        if (isset($this->ignoredErrorsOnPackage[$packageName][$errorType])) {
-            $this->ignoredErrorsOnPackage[$packageName][$errorType] = true;
+        if (isset($this->ignoredErrorsOnDependency[$dependency][$errorType])) {
+            $this->ignoredErrorsOnDependency[$dependency][$errorType] = true;
             return true;
         }
 
@@ -294,12 +294,12 @@ class IgnoreList
     /**
      * @param ErrorType::* $errorType
      */
-    private function shouldIgnoreErrorOnPackageAndPath(string $errorType, string $packageName, string $filePath): bool
+    private function shouldIgnoreErrorOnDependencyAndPath(string $errorType, string $packageName, string $filePath): bool
     {
-        if (isset($this->ignoredErrorsOnPackageAndPath[$packageName])) {
-            foreach ($this->ignoredErrorsOnPackageAndPath[$packageName] as $path => $errorTypes) {
+        if (isset($this->ignoredErrorsOnDependencyAndPath[$packageName])) {
+            foreach ($this->ignoredErrorsOnDependencyAndPath[$packageName] as $path => $errorTypes) {
                 if ($this->isFilepathWithinPath($filePath, $path) && isset($errorTypes[$errorType])) {
-                    $this->ignoredErrorsOnPackageAndPath[$packageName][$path][$errorType] = true;
+                    $this->ignoredErrorsOnDependencyAndPath[$packageName][$path][$errorType] = true;
                     return true;
                 }
             }

--- a/src/Initializer.php
+++ b/src/Initializer.php
@@ -52,6 +52,8 @@ Ignore options:
     --ignore-shadow-deps                Ignore all shadow dependency issues
     --ignore-dev-in-prod-deps           Ignore all dev dependency in production code issues
     --ignore-prod-only-in-dev-deps      Ignore all prod dependency used only in dev paths issues
+
+    --disable-ext-analysis              Disable analysis of php extensions (e.g. ext-xml)
 EOD;
 
     /**
@@ -116,12 +118,17 @@ EOD;
             $config = new Configuration();
         }
 
+        $disableExtAnalysis = $options->disableExtAnalysis === true;
         $ignoreUnknownClasses = $options->ignoreUnknownClasses === true;
         $ignoreUnknownFunctions = $options->ignoreUnknownFunctions === true;
         $ignoreUnused = $options->ignoreUnusedDeps === true;
         $ignoreShadow = $options->ignoreShadowDeps === true;
         $ignoreDevInProd = $options->ignoreDevInProdDeps === true;
         $ignoreProdOnlyInDev = $options->ignoreProdOnlyInDevDeps === true;
+
+        if ($disableExtAnalysis) {
+            $config->disableExtensionsAnalysis();
+        }
 
         if ($ignoreUnknownClasses) {
             $config->ignoreErrors([ErrorType::UNKNOWN_CLASS]);

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -155,14 +155,14 @@ class UsedSymbolExtractor
                             break;
                         }
 
-                        if (isset($extensionSymbols[$lowerName])) {
-                            $symbolName = $name;
-                            $kind = $extensionSymbols[$lowerName];
-                            $usedSymbols[$kind][$symbolName][] = $token[2];
-
-                        } elseif (isset($useStatements[$name])) {
+                        if (isset($useStatements[$name])) {
                             $symbolName = $useStatements[$name];
                             $kind = $useStatementKinds[$name];
+                            $usedSymbols[$kind][$symbolName][] = $token[2];
+
+                        } elseif (isset($extensionSymbols[$lowerName])) {
+                            $symbolName = $name;
+                            $kind = $extensionSymbols[$lowerName];
                             $usedSymbols[$kind][$symbolName][] = $token[2];
                         }
 

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -2,9 +2,6 @@
 
 namespace ShipMonk\ComposerDependencyAnalyser;
 
-use function array_fill_keys;
-use function array_map;
-use function array_merge;
 use function count;
 use function explode;
 use function is_array;
@@ -70,24 +67,15 @@ class UsedSymbolExtractor
      * It does not produce any local names in current namespace
      * - this results in very limited functionality in files without namespace
      *
-     * @param list<string> $extClasses
-     * @param list<string> $extFunctions
-     * @param list<string> $extConstants
+     * @param array<string, SymbolKind::*> $extensionSymbols
      * @return array<SymbolKind::*, array<string, list<int>>>
      * @license Inspired by https://github.com/doctrine/annotations/blob/2.0.0/lib/Doctrine/Common/Annotations/TokenParser.php
      */
     public function parseUsedSymbols(
-        array $extClasses,
-        array $extFunctions,
-        array $extConstants
+        array $extensionSymbols
     ): array
     {
         $usedSymbols = [];
-        $extensionSymbols = array_merge(
-            array_fill_keys(array_map('strtolower', $extClasses), SymbolKind::CLASSLIKE),
-            array_fill_keys(array_map('strtolower', $extFunctions), SymbolKind::FUNCTION),
-            array_fill_keys(array_map('strtolower', $extConstants), SymbolKind::CONSTANT)
-        );
         $useStatements = [];
         $useStatementKinds = [];
 

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -411,6 +411,7 @@ class UsedSymbolExtractor
             || $tokenBeforeName[0] === T_AS
             || $tokenBeforeName[0] === T_FUNCTION
             || $tokenBeforeName[0] === T_OBJECT_OPERATOR
+            || $tokenBeforeName[0] === T_NAMESPACE
             || $tokenBeforeName[0] === (PHP_VERSION_ID > 80000 ? T_NULLSAFE_OBJECT_OPERATOR : -1)
             || $tokenAfterName[0] === T_INSTEADOF
             || $tokenAfterName[0] === T_AS

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -609,6 +609,48 @@ class AnalyserTest extends TestCase
         self::assertEquals($this->createAnalysisResult(1, []), $result);
     }
 
+    public function testExtensions(): void
+    {
+        $vendorDir = realpath(__DIR__ . '/../vendor');
+        $prodPath = realpath(__DIR__ . '/data/not-autoloaded/extensions/ext-prod-usages.php');
+        $devPath = realpath(__DIR__ . '/data/not-autoloaded/extensions/ext-dev-usages.php');
+        self::assertNotFalse($vendorDir);
+        self::assertNotFalse($prodPath);
+        self::assertNotFalse($devPath);
+
+        $config = new Configuration();
+        $config->addPathToScan($prodPath, false);
+        $config->addPathToScan($devPath, true);
+
+        $detector = new Analyser(
+            $this->getStopwatchMock(),
+            $vendorDir,
+            [$vendorDir => $this->getClassLoaderMock()],
+            $config,
+            [
+                'ext-dom' => false,
+                'ext-libxml' => true,
+                'ext-mbstring' => false,
+            ]
+        );
+        $result = $detector->run();
+
+        $this->assertResultsWithoutUsages($this->createAnalysisResult(2, [
+            ErrorType::SHADOW_DEPENDENCY => [
+                'ext-pdo' => ['PDO' => [new SymbolUsage($prodPath, 5, SymbolKind::CLASSLIKE)]],
+            ],
+            ErrorType::DEV_DEPENDENCY_IN_PROD => [
+                'ext-libxml' => ['LIBXML_NOEMPTYTAG' => [new SymbolUsage($prodPath, 3, SymbolKind::CONSTANT)]],
+            ],
+            ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV => [
+                'ext-dom',
+            ],
+            ErrorType::UNUSED_DEPENDENCY => [
+                'ext-mbstring',
+            ],
+        ]), $result);
+    }
+
     public function testPharSupport(): void
     {
         $canCreatePhar = ini_set('phar.readonly', '0');

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -834,6 +834,7 @@ class AnalyserTest extends TestCase
         self::assertSame($expectedResult->getScannedFilesCount(), $result->getScannedFilesCount(), 'Scanned files count mismatch');
         self::assertEquals($expectedResult->getUnusedIgnores(), $result->getUnusedIgnores(), 'Unused ignores mismatch');
         self::assertEquals($expectedResult->getUnknownClassErrors(), $result->getUnknownClassErrors(), 'Unknown class mismatch');
+        self::assertEquals($expectedResult->getUnknownFunctionErrors(), $result->getUnknownFunctionErrors(), 'Unknown functions mismatch');
         self::assertEquals($expectedResult->getShadowDependencyErrors(), $result->getShadowDependencyErrors(), 'Shadow dependency mismatch');
         self::assertEquals($expectedResult->getDevDependencyInProductionErrors(), $result->getDevDependencyInProductionErrors(), 'Dev dependency in production mismatch');
         self::assertEquals($expectedResult->getProdDependencyOnlyInDevErrors(), $result->getProdDependencyOnlyInDevErrors(), 'Prod dependency only in dev mismatch');

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -651,6 +651,36 @@ class AnalyserTest extends TestCase
         ]), $result);
     }
 
+    public function testDisabledExtensionAnalysis(): void
+    {
+        $vendorDir = realpath(__DIR__ . '/../vendor');
+        $prodPath = realpath(__DIR__ . '/data/not-autoloaded/extensions/ext-prod-usages.php');
+        $devPath = realpath(__DIR__ . '/data/not-autoloaded/extensions/ext-dev-usages.php');
+        self::assertNotFalse($vendorDir);
+        self::assertNotFalse($prodPath);
+        self::assertNotFalse($devPath);
+
+        $config = new Configuration();
+        $config->disableExtensionsAnalysis();
+        $config->addPathToScan($prodPath, false);
+        $config->addPathToScan($devPath, true);
+
+        $detector = new Analyser(
+            $this->getStopwatchMock(),
+            $vendorDir,
+            [$vendorDir => $this->getClassLoaderMock()],
+            $config,
+            [
+                'ext-dom' => false,
+                'ext-libxml' => true,
+                'ext-mbstring' => false,
+            ]
+        );
+        $result = $detector->run();
+
+        $this->assertResultsWithoutUsages($this->createAnalysisResult(2, []), $result);
+    }
+
     public function testPharSupport(): void
     {
         $canCreatePhar = ini_set('phar.readonly', '0');

--- a/tests/BinTest.php
+++ b/tests/BinTest.php
@@ -17,7 +17,7 @@ class BinTest extends TestCase
         $testsDir = __DIR__;
 
         $noComposerJsonError = 'File composer.json not found';
-        $noPackagesError = 'No packages found';
+        $noPackagesError = 'No dependencies found';
         $parseError = 'Failure while parsing';
         $junitDumpError = "Cannot use 'junit' format with '--dump-usages' option";
 

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -53,11 +53,12 @@ class CliTest extends TestCase
 
         yield 'valid bool options' => [
             null,
-            ['bin/script.php', '--help', '--verbose', '--ignore-shadow-deps', '--ignore-unused-deps', '--ignore-dev-in-prod-deps', '--ignore-unknown-classes', '--ignore-unknown-functions'],
+            ['bin/script.php', '--help', '--verbose', '--ignore-shadow-deps', '--ignore-unused-deps', '--ignore-dev-in-prod-deps', '--ignore-unknown-classes', '--ignore-unknown-functions', '--disable-ext-analysis'],
             (static function (): CliOptions {
                 $options = new CliOptions();
                 $options->help = true;
                 $options->verbose = true;
+                $options->disableExtAnalysis = true;
                 $options->ignoreShadowDeps = true;
                 $options->ignoreUnusedDeps = true;
                 $options->ignoreDevInProdDeps = true;

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -21,6 +21,7 @@ class ConfigurationTest extends TestCase
         $configuration->ignoreUnknownClasses(['Unknown\Clazz']);
         $configuration->ignoreErrors([ErrorType::UNUSED_DEPENDENCY, ErrorType::UNKNOWN_CLASS]);
         $configuration->ignoreErrorsOnPath(__DIR__ . '/data/../', [ErrorType::SHADOW_DEPENDENCY]);
+        $configuration->ignoreErrorsOnExtension('ext-xml', [ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV]);
         $configuration->ignoreErrorsOnPackage('my/package', [ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV]);
         $configuration->ignoreErrorsOnPackageAndPath('vendor/package', __DIR__ . '/../tests/data', [ErrorType::DEV_DEPENDENCY_IN_PROD]);
 
@@ -41,6 +42,13 @@ class ConfigurationTest extends TestCase
         self::assertTrue($ignoreList->shouldIgnoreError(ErrorType::SHADOW_DEPENDENCY, __DIR__, 'some/package'));
         self::assertTrue($ignoreList->shouldIgnoreError(ErrorType::SHADOW_DEPENDENCY, __DIR__ . DIRECTORY_SEPARATOR . 'app', null));
         self::assertTrue($ignoreList->shouldIgnoreError(ErrorType::SHADOW_DEPENDENCY, __DIR__ . DIRECTORY_SEPARATOR . 'app', 'some/package'));
+
+        self::assertFalse($ignoreList->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, null));
+        self::assertFalse($ignoreList->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, 'ext-simplexml'));
+        self::assertTrue($ignoreList->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, 'ext-xml'));
+        self::assertFalse($ignoreList->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, __DIR__, null));
+        self::assertFalse($ignoreList->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, __DIR__, 'ext-simplexml'));
+        self::assertTrue($ignoreList->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, __DIR__, 'ext-xml'));
 
         self::assertFalse($ignoreList->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, null));
         self::assertFalse($ignoreList->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, 'some/package'));

--- a/tests/InitializerTest.php
+++ b/tests/InitializerTest.php
@@ -99,6 +99,7 @@ class InitializerTest extends TestCase
 
         self::assertNull($options->showAllUsages);
         self::assertNull($options->composerJson);
+        self::assertNull($options->disableExtAnalysis);
         self::assertNull($options->ignoreProdOnlyInDevDeps);
         self::assertNull($options->ignoreUnknownClasses);
         self::assertNull($options->ignoreUnknownFunctions);

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -25,6 +25,7 @@ class UsedSymbolExtractorTest extends TestCase
             $expectedUsages,
             $extractor->parseUsedSymbols(
                 [
+                    strtolower('XMLReader') => SymbolKind::CLASSLIKE,
                     strtolower('PDO') => SymbolKind::CLASSLIKE,
                     strtolower('json_encode') => SymbolKind::FUNCTION,
                     strtolower('DDTrace\active_span') => SymbolKind::FUNCTION,
@@ -153,6 +154,7 @@ class UsedSymbolExtractorTest extends TestCase
                 ],
                 SymbolKind::CLASSLIKE => [
                     'PDO' => [11],
+                    'My\App\XMLReader' => [15],
                     'CURLOPT_SSL_VERIFYHOST' => [19],
                 ],
             ],
@@ -174,6 +176,7 @@ class UsedSymbolExtractorTest extends TestCase
                 ],
                 SymbolKind::CLASSLIKE => [
                     'PDO' => [11],
+                    'My\App\XMLReader' => [15],
                     'CURLOPT_SSL_VERIFYHOST' => [19],
                 ],
             ],

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -12,9 +12,10 @@ class UsedSymbolExtractorTest extends TestCase
 
     /**
      * @param array<SymbolKind::*, array<string, list<int>>> $expectedUsages
+     * @param array<string, SymbolKind::*> $extensionSymbols
      * @dataProvider provideVariants
      */
-    public function test(string $path, array $expectedUsages): void
+    public function test(string $path, array $expectedUsages, array $extensionSymbols = []): void
     {
         $code = file_get_contents($path);
         self::assertNotFalse($code);
@@ -23,24 +24,12 @@ class UsedSymbolExtractorTest extends TestCase
 
         self::assertSame(
             $expectedUsages,
-            $extractor->parseUsedSymbols(
-                [
-                    strtolower('XMLReader') => SymbolKind::CLASSLIKE,
-                    strtolower('PDO') => SymbolKind::CLASSLIKE,
-                    strtolower('json_encode') => SymbolKind::FUNCTION,
-                    strtolower('DDTrace\active_span') => SymbolKind::FUNCTION,
-                    strtolower('DDTrace\root_span') => SymbolKind::FUNCTION,
-                    strtolower('LIBXML_ERR_FATAL') => SymbolKind::CONSTANT,
-                    strtolower('LIBXML_ERR_ERROR') => SymbolKind::CONSTANT,
-                    strtolower('DDTrace\DBM_PROPAGATION_FULL') => SymbolKind::CONSTANT,
-                    strtolower('DDTrace\Integrations\Exec\proc_get_pid') => SymbolKind::FUNCTION,
-                ]
-            )
+            $extractor->parseUsedSymbols($extensionSymbols)
         );
     }
 
     /**
-     * @return iterable<array{string, array<SymbolKind::*, array<string, list<int>>>}>
+     * @return iterable<array{0: string, 1: array<SymbolKind::*, array<string, list<int>>>, 2?: array<string, SymbolKind::*>}>
      */
     public function provideVariants(): iterable
     {
@@ -68,6 +57,9 @@ class UsedSymbolExtractorTest extends TestCase
         yield 'T_STRING issues' => [
             __DIR__ . '/data/not-autoloaded/used-symbols/t-string-issues.php',
             [],
+            [
+                strtolower('PDO') => SymbolKind::CLASSLIKE,
+            ],
         ];
 
         yield 'various usages' => [
@@ -160,6 +152,7 @@ class UsedSymbolExtractorTest extends TestCase
                     'CURLOPT_SSL_VERIFYHOST' => [19],
                 ],
             ],
+            self::extensionSymbolsForExtensionsTestCases(),
         ];
 
         yield 'extensions global' => [
@@ -183,6 +176,7 @@ class UsedSymbolExtractorTest extends TestCase
                     'CURLOPT_SSL_VERIFYHOST' => [19],
                 ],
             ],
+            self::extensionSymbolsForExtensionsTestCases(),
         ];
 
         if (PHP_VERSION_ID >= 80000) {
@@ -204,6 +198,24 @@ class UsedSymbolExtractorTest extends TestCase
                 [],
             ];
         }
+    }
+
+    /**
+     * @return array<string, SymbolKind::*>
+     */
+    private static function extensionSymbolsForExtensionsTestCases(): array
+    {
+        return [
+            strtolower('XMLReader') => SymbolKind::CLASSLIKE,
+            strtolower('PDO') => SymbolKind::CLASSLIKE,
+            strtolower('json_encode') => SymbolKind::FUNCTION,
+            strtolower('DDTrace\active_span') => SymbolKind::FUNCTION,
+            strtolower('DDTrace\root_span') => SymbolKind::FUNCTION,
+            strtolower('LIBXML_ERR_FATAL') => SymbolKind::CONSTANT,
+            strtolower('LIBXML_ERR_ERROR') => SymbolKind::CONSTANT,
+            strtolower('DDTrace\DBM_PROPAGATION_FULL') => SymbolKind::CONSTANT,
+            strtolower('DDTrace\Integrations\Exec\proc_get_pid') => SymbolKind::FUNCTION,
+        ];
     }
 
 }

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -3,6 +3,7 @@
 namespace ShipMonk\ComposerDependencyAnalyser;
 
 use PHPUnit\Framework\TestCase;
+use function array_map;
 use function file_get_contents;
 use const PHP_VERSION_ID;
 
@@ -20,7 +21,14 @@ class UsedSymbolExtractorTest extends TestCase
 
         $extractor = new UsedSymbolExtractor($code);
 
-        self::assertSame($expectedUsages, $extractor->parseUsedSymbols(['PDO'], ['json_encode'], ['LIBXML_ERR_FATAL']));
+        self::assertSame(
+            $expectedUsages,
+            $extractor->parseUsedSymbols(
+                ['PDO'],
+                array_map('strtolower', ['json_encode', 'DDTrace\active_span', 'DDTrace\root_span']),
+                ['LIBXML_ERR_FATAL', 'LIBXML_ERR_ERROR', 'DDTrace\DBM_PROPAGATION_FULL']
+            )
+        );
     }
 
     /**
@@ -47,6 +55,11 @@ class UsedSymbolExtractorTest extends TestCase
                     'PHPUnit\Framework\assertEquals' => [38],
                 ],
             ],
+        ];
+
+        yield 'T_STRING issues' => [
+            __DIR__ . '/data/not-autoloaded/used-symbols/t-string-issues.php',
+            [],
         ];
 
         yield 'various usages' => [
@@ -122,15 +135,40 @@ class UsedSymbolExtractorTest extends TestCase
             __DIR__ . '/data/not-autoloaded/used-symbols/extensions.php',
             [
                 SymbolKind::FUNCTION => [
-                    'json_encode' => [5],
-                    'json_decode' => [12],
+                    'json_encode' => [8],
+                    'DDTrace\active_span' => [12],
+                    'DDTrace\root_span' => [13],
+                    'json_decode' => [21],
                 ],
                 SymbolKind::CONSTANT => [
-                    'LIBXML_ERR_FATAL' => [6],
+                    'LIBXML_ERR_FATAL' => [9],
+                    'LIBXML_ERR_ERROR' => [10],
+                    'DDTrace\DBM_PROPAGATION_FULL' => [14],
                 ],
                 SymbolKind::CLASSLIKE => [
-                    'PDO' => [7],
-                    'CURLOPT_SSL_VERIFYHOST' => [10],
+                    'PDO' => [11],
+                    'CURLOPT_SSL_VERIFYHOST' => [19],
+                ],
+            ],
+        ];
+
+        yield 'extensions global' => [
+            __DIR__ . '/data/not-autoloaded/used-symbols/extensions-global.php',
+            [
+                SymbolKind::FUNCTION => [
+                    'json_encode' => [8],
+                    'DDTrace\active_span' => [12],
+                    'DDTrace\root_span' => [13],
+                    'json_decode' => [21],
+                ],
+                SymbolKind::CONSTANT => [
+                    'LIBXML_ERR_FATAL' => [9],
+                    'LIBXML_ERR_ERROR' => [10],
+                    'DDTrace\DBM_PROPAGATION_FULL' => [14],
+                ],
+                SymbolKind::CLASSLIKE => [
+                    'PDO' => [11],
+                    'CURLOPT_SSL_VERIFYHOST' => [19],
                 ],
             ],
         ];

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -20,7 +20,7 @@ class UsedSymbolExtractorTest extends TestCase
 
         $extractor = new UsedSymbolExtractor($code);
 
-        self::assertSame($expectedUsages, $extractor->parseUsedSymbols());
+        self::assertSame($expectedUsages, $extractor->parseUsedSymbols(['PDO'], ['json_encode'], ['LIBXML_ERR_FATAL']));
     }
 
     /**
@@ -116,6 +116,23 @@ class UsedSymbolExtractorTest extends TestCase
         yield 'curly braces' => [
             __DIR__ . '/data/not-autoloaded/used-symbols/curly-braces.php',
             [],
+        ];
+
+        yield 'extensions' => [
+            __DIR__ . '/data/not-autoloaded/used-symbols/extensions.php',
+            [
+                SymbolKind::FUNCTION => [
+                    'json_encode' => [5],
+                    'json_decode' => [12],
+                ],
+                SymbolKind::CONSTANT => [
+                    'LIBXML_ERR_FATAL' => [6],
+                ],
+                SymbolKind::CLASSLIKE => [
+                    'PDO' => [7],
+                    'CURLOPT_SSL_VERIFYHOST' => [10],
+                ],
+            ],
         ];
 
         if (PHP_VERSION_ID >= 80000) {

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -33,6 +33,7 @@ class UsedSymbolExtractorTest extends TestCase
                     strtolower('LIBXML_ERR_FATAL') => SymbolKind::CONSTANT,
                     strtolower('LIBXML_ERR_ERROR') => SymbolKind::CONSTANT,
                     strtolower('DDTrace\DBM_PROPAGATION_FULL') => SymbolKind::CONSTANT,
+                    strtolower('DDTrace\Integrations\Exec\proc_get_pid') => SymbolKind::FUNCTION,
                 ]
             )
         );
@@ -145,6 +146,7 @@ class UsedSymbolExtractorTest extends TestCase
                     'json_encode' => [8],
                     'DDTrace\active_span' => [12],
                     'DDTrace\root_span' => [13],
+                    'DDTrace\Integrations\Exec\proc_get_pid' => [16],
                     'json_decode' => [21],
                 ],
                 SymbolKind::CONSTANT => [
@@ -167,6 +169,7 @@ class UsedSymbolExtractorTest extends TestCase
                     'json_encode' => [8],
                     'DDTrace\active_span' => [12],
                     'DDTrace\root_span' => [13],
+                    'DDTrace\Integrations\Exec\proc_get_pid' => [16],
                     'json_decode' => [21],
                 ],
                 SymbolKind::CONSTANT => [

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -3,8 +3,8 @@
 namespace ShipMonk\ComposerDependencyAnalyser;
 
 use PHPUnit\Framework\TestCase;
-use function array_map;
 use function file_get_contents;
+use function strtolower;
 use const PHP_VERSION_ID;
 
 class UsedSymbolExtractorTest extends TestCase
@@ -24,9 +24,15 @@ class UsedSymbolExtractorTest extends TestCase
         self::assertSame(
             $expectedUsages,
             $extractor->parseUsedSymbols(
-                ['PDO'],
-                array_map('strtolower', ['json_encode', 'DDTrace\active_span', 'DDTrace\root_span']),
-                ['LIBXML_ERR_FATAL', 'LIBXML_ERR_ERROR', 'DDTrace\DBM_PROPAGATION_FULL']
+                [
+                    strtolower('PDO') => SymbolKind::CLASSLIKE,
+                    strtolower('json_encode') => SymbolKind::FUNCTION,
+                    strtolower('DDTrace\active_span') => SymbolKind::FUNCTION,
+                    strtolower('DDTrace\root_span') => SymbolKind::FUNCTION,
+                    strtolower('LIBXML_ERR_FATAL') => SymbolKind::CONSTANT,
+                    strtolower('LIBXML_ERR_ERROR') => SymbolKind::CONSTANT,
+                    strtolower('DDTrace\DBM_PROPAGATION_FULL') => SymbolKind::CONSTANT,
+                ]
             )
         );
     }

--- a/tests/data/not-autoloaded/extensions/ext-dev-usages.php
+++ b/tests/data/not-autoloaded/extensions/ext-dev-usages.php
@@ -1,0 +1,3 @@
+<?php
+
+echo DOMDocument::class; // ext-dom

--- a/tests/data/not-autoloaded/extensions/ext-dev-usages.php
+++ b/tests/data/not-autoloaded/extensions/ext-dev-usages.php
@@ -1,3 +1,4 @@
 <?php
 
 echo DOMDocument::class; // ext-dom
+DOM_import_simplexml(); // functions are case insensitive, this must not be unknown function

--- a/tests/data/not-autoloaded/extensions/ext-prod-usages.php
+++ b/tests/data/not-autoloaded/extensions/ext-prod-usages.php
@@ -1,0 +1,6 @@
+<?php
+
+echo LIBXML_NOEMPTYTAG; // ext-libxml
+echo json_encode([]); // ext-json, is core
+echo PDO::class; // ext-pdo
+

--- a/tests/data/not-autoloaded/used-symbols/extensions-global.php
+++ b/tests/data/not-autoloaded/used-symbols/extensions-global.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Extensions;
 
-use DDTrace;
+
+
 use function DDTrace\active_span;
 
 json_encode('');

--- a/tests/data/not-autoloaded/used-symbols/extensions-global.php
+++ b/tests/data/not-autoloaded/used-symbols/extensions-global.php
@@ -2,7 +2,7 @@
 
 
 
-
+use My\App\XMLReader;
 use function DDTrace\active_span;
 
 json_encode('');
@@ -12,7 +12,7 @@ PDO::class;
 active_span();
 DDTrace\root_span();
 DDTrace\DBM_PROPAGATION_FULL;
-
+XMLReader::class;
 
 
 // those are not provided as known ext symbols in the test

--- a/tests/data/not-autoloaded/used-symbols/extensions-global.php
+++ b/tests/data/not-autoloaded/used-symbols/extensions-global.php
@@ -1,7 +1,7 @@
 <?php
 
 
-
+use { DDTrace\Integrations };
 use My\App\XMLReader;
 use function DDTrace\active_span;
 
@@ -13,7 +13,7 @@ active_span();
 DDTrace\root_span();
 DDTrace\DBM_PROPAGATION_FULL;
 XMLReader::class;
-
+Integrations\Exec\proc_get_pid();
 
 // those are not provided as known ext symbols in the test
 \CURLOPT_SSL_VERIFYHOST;

--- a/tests/data/not-autoloaded/used-symbols/extensions.php
+++ b/tests/data/not-autoloaded/used-symbols/extensions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Extensions;
+
+json_encode('');
+LIBXML_ERR_FATAL;
+PDO::class;
+
+// those are not provided as known ext symbols in the test
+\CURLOPT_SSL_VERIFYHOST;
+CURLOPT_SSL_VERIFYPEER;
+\json_decode('');
+ZipArchive::class;

--- a/tests/data/not-autoloaded/used-symbols/extensions.php
+++ b/tests/data/not-autoloaded/used-symbols/extensions.php
@@ -1,7 +1,7 @@
 <?php
 namespace Extensions;
 
-use DDTrace;
+use { DDTrace, DDTrace\Integrations };
 use function DDTrace\active_span;
 use My\App\XMLReader;
 
@@ -13,7 +13,7 @@ active_span();
 DDTrace\root_span();
 DDTrace\DBM_PROPAGATION_FULL;
 XMLReader::class;
-
+Integrations\Exec\proc_get_pid();
 
 // those are not provided as known ext symbols in the test
 \CURLOPT_SSL_VERIFYHOST;

--- a/tests/data/not-autoloaded/used-symbols/extensions.php
+++ b/tests/data/not-autoloaded/used-symbols/extensions.php
@@ -1,9 +1,9 @@
 <?php
-
 namespace Extensions;
 
 use DDTrace;
 use function DDTrace\active_span;
+use My\App\XMLReader;
 
 json_encode('');
 LIBXML_ERR_FATAL;
@@ -12,7 +12,7 @@ PDO::class;
 active_span();
 DDTrace\root_span();
 DDTrace\DBM_PROPAGATION_FULL;
-
+XMLReader::class;
 
 
 // those are not provided as known ext symbols in the test

--- a/tests/data/not-autoloaded/used-symbols/t-string-issues.php
+++ b/tests/data/not-autoloaded/used-symbols/t-string-issues.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TString;
+namespace PDO;
 
 use function _; // e.g. https://www.php.net/manual/en/function.-.php
 use function array_filter;

--- a/tests/data/not-autoloaded/used-symbols/t-string-issues.php
+++ b/tests/data/not-autoloaded/used-symbols/t-string-issues.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TString;
+
+use function _; // e.g. https://www.php.net/manual/en/function.-.php
+use function array_filter;
+use function array_values;
+use function array_map;
+use function array_walk;
+
+class Test
+{
+    use SomeTrait {
+        array_filter insteadof array_values;
+        array_map as array_walk;
+    }
+
+    public function _(): void {
+        $this->array_filter();
+        $this?->array_filter();
+        self::array_filter();
+    }
+
+}


### PR DESCRIPTION
- [x] More tests
- [x] Extension name normalization
  - Just [like composer does it](https://github.com/composer/composer/blob/bbb6034/src/Composer/Repository/PlatformRepository.php#L682)
- [x] Support `ignoreErrorsOnExtension` 
  - along with existing `ignoreErrorsOnPackage`
- [x] Ability to disable `ext-` analysis 
  - (via `--disable-ext-analysis` & `$config->disableExtensionsAnalysis()`)