### PR TITLE
only print message if console format is used

### DIFF
--- a/bin/composer-dependency-analyser
+++ b/bin/composer-dependency-analyser
@@ -36,7 +36,7 @@ try {
     $composerJson = $initializer->initComposerJson($options);
     $initializer->initComposerAutoloader($composerJson);
     $configuration = $initializer->initConfiguration($options, $composerJson);
-    $classLoaders = $initializer->initComposerClassLoaders();
+    $classLoaders = $initializer->initComposerClassLoaders($options);
 
     $analyser = new Analyser($stopwatch, $classLoaders, $configuration, $composerJson->dependencies);
     $result = $analyser->run();

--- a/src/Initializer.php
+++ b/src/Initializer.php
@@ -85,7 +85,9 @@ EOD;
         }
 
         if (is_file($configPath)) {
-            $this->printer->printLine('<gray>Using config</gray> ' . $configPath);
+            if ($options->format === null || $options->format === 'console') {
+                $this->printer->printLine('<gray>Using config</gray> ' . $configPath);
+            }
 
             try {
                 $config = (static function () use ($configPath) {

--- a/src/Initializer.php
+++ b/src/Initializer.php
@@ -187,22 +187,24 @@ EOD;
     /**
      * @return array<string, ClassLoader>
      */
-    public function initComposerClassLoaders(): array
+    public function initComposerClassLoaders(CliOptions $options): array
     {
         $loaders = ClassLoader::getRegisteredLoaders();
 
-        if (count($loaders) > 1) {
-            $this->printer->printLine("\nDetected multiple class loaders:");
+        if ($options->format === null || $options->format === 'console') {
+            if (count($loaders) > 1) {
+                $this->printer->printLine("\nDetected multiple class loaders:");
 
-            foreach ($loaders as $vendorDir => $_) {
-                $this->printer->printLine(" • <gray>$vendorDir</gray>");
+                foreach ($loaders as $vendorDir => $_) {
+                    $this->printer->printLine(" • <gray>$vendorDir</gray>");
+                }
+
+                $this->printer->printLine('');
             }
 
-            $this->printer->printLine('');
-        }
-
-        if (count($loaders) === 0) {
-            $this->printer->printLine("\nNo composer class loader detected!\n");
+            if (count($loaders) === 0) {
+                $this->printer->printLine("\nNo composer class loader detected!\n");
+            }
         }
 
         return $loaders;


### PR DESCRIPTION
Bugfix patch for my junit formatter. 

Finally found time to test it with CI/CD and found one issue:

```
[37mUsing config[0m /Users/xxx/composer-dependency-analyser.php
<?xml version="1.0" encoding="UTF-8"?><testsuites><testsuite name="shadow dependencies" failures="1"><testcase name="laminas/laminas-uri"><failure>e.g. Laminas\Uri\Uri in src/Infrastructure/ExternalService/Url/UrlService.php:45 (+ 10 more)</failure></testcase></testsuite></testsuites>
```

The first line breaks the valid xml and I would have to remove it by script. 