### PR TITLE
`exclude-from-classmap` support

### DIFF
--- a/src/ComposerJson.php
+++ b/src/ComposerJson.php
@@ -54,12 +54,12 @@ class ComposerJson
     public $autoloadPaths;
 
     /**
-     * Regexp => isDev
+     * Regex => isDev
      *
      * @readonly
      * @var array<string, bool>
      */
-    public $autoloadExcludeRegexps;
+    public $autoloadExcludeRegexes;
 
     /**
      * @throws InvalidPathException
@@ -87,9 +87,9 @@ class ComposerJson
             $this->extractAutoloadPaths($basePath, $composerJsonData['autoload-dev']['files'] ?? [], true),
             $this->extractAutoloadPaths($basePath, $composerJsonData['autoload-dev']['classmap'] ?? [], true)
         );
-        $this->autoloadExcludeRegexps = array_merge(
-            $this->extractAutoloadExcludeRegexps($basePath, $composerJsonData['autoload']['exclude-from-classmap'] ?? [], false),
-            $this->extractAutoloadExcludeRegexps($basePath, $composerJsonData['autoload-dev']['exclude-from-classmap'] ?? [], true)
+        $this->autoloadExcludeRegexes = array_merge(
+            $this->extractAutoloadExcludeRegexes($basePath, $composerJsonData['autoload']['exclude-from-classmap'] ?? [], false),
+            $this->extractAutoloadExcludeRegexes($basePath, $composerJsonData['autoload-dev']['exclude-from-classmap'] ?? [], true)
         );
 
         $filterPackages = static function (string $package): bool {
@@ -149,15 +149,15 @@ class ComposerJson
      * @return array<string, bool>
      * @throws InvalidPathException
      */
-    private function extractAutoloadExcludeRegexps(string $basePath, array $exclude, bool $isDev): array
+    private function extractAutoloadExcludeRegexes(string $basePath, array $exclude, bool $isDev): array
     {
-        $regexps = [];
+        $regexes = [];
 
         foreach ($exclude as $path) {
-            $regexps[$this->resolveAutoloadExclude($basePath, $path)] = $isDev;
+            $regexes[$this->resolveAutoloadExclude($basePath, $path)] = $isDev;
         }
 
-        return $regexps;
+        return $regexes;
     }
 
     /**

--- a/src/ComposerJson.php
+++ b/src/ComposerJson.php
@@ -193,7 +193,7 @@ class ComposerJson
                 return '';
             },
             $path
-            // note: composer also use `PREG_UNMATCHED_AS_NULL` but it is supported since PHP v7.4
+            // note: composer also uses `PREG_UNMATCHED_AS_NULL` but the `$flags` arg supported since PHP v7.4
         );
 
         if ($path === null) {

--- a/src/ComposerJson.php
+++ b/src/ComposerJson.php
@@ -17,7 +17,14 @@ use function is_file;
 use function json_decode;
 use function json_last_error;
 use function json_last_error_msg;
+use function preg_quote;
+use function preg_replace;
+use function preg_replace_callback;
+use function realpath;
+use function str_replace;
 use function strpos;
+use function strtr;
+use function trim;
 use const ARRAY_FILTER_USE_KEY;
 use const JSON_ERROR_NONE;
 
@@ -47,6 +54,14 @@ class ComposerJson
     public $autoloadPaths;
 
     /**
+     * Regexp => isDev
+     *
+     * @readonly
+     * @var array<string, bool>
+     */
+    public $autoloadExcludeRegexps;
+
+    /**
      * @throws InvalidPathException
      * @throws InvalidConfigException
      */
@@ -71,6 +86,10 @@ class ComposerJson
             $this->extractAutoloadPaths($basePath, $composerJsonData['autoload-dev']['psr-4'] ?? [], true),
             $this->extractAutoloadPaths($basePath, $composerJsonData['autoload-dev']['files'] ?? [], true),
             $this->extractAutoloadPaths($basePath, $composerJsonData['autoload-dev']['classmap'] ?? [], true)
+        );
+        $this->autoloadExcludeRegexps = array_merge(
+            $this->extractAutoloadExcludeRegexps($basePath, $composerJsonData['autoload']['exclude-from-classmap'] ?? [], false),
+            $this->extractAutoloadExcludeRegexps($basePath, $composerJsonData['autoload-dev']['exclude-from-classmap'] ?? [], true)
         );
 
         $filterPackages = static function (string $package): bool {
@@ -126,6 +145,76 @@ class ComposerJson
     }
 
     /**
+     * @param array<string> $exclude
+     * @return array<string, bool>
+     * @throws InvalidPathException
+     */
+    private function extractAutoloadExcludeRegexps(string $basePath, array $exclude, bool $isDev): array
+    {
+        $regexps = [];
+
+        foreach ($exclude as $path) {
+            $regexps[$this->resolveAutoloadExclude($basePath, $path)] = $isDev;
+        }
+
+        return $regexps;
+    }
+
+    /**
+     * Implementation copied from composer/composer.
+     *
+     * @license MIT https://github.com/composer/composer/blob/ee2c9afdc86ef3f06a4bd49b1fea7d1d636afc92/LICENSE
+     * @see https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps
+     * @see https://github.com/composer/composer/blob/ee2c9afdc86ef3f06a4bd49b1fea7d1d636afc92/src/Composer/Autoload/AutoloadGenerator.php#L1256-L1286
+     * @throws InvalidPathException
+     */
+    private function resolveAutoloadExclude(string $basePath, string $pathPattern): string
+    {
+        // first escape user input
+        $path = preg_replace('{/+}', '/', preg_quote(trim(strtr($pathPattern, '\\', '/'), '/')));
+
+        if ($path === null) {
+            throw new InvalidPathException("Failure while globbing $pathPattern path.");
+        }
+
+        // add support for wildcards * and **
+        $path = strtr($path, ['\\*\\*' => '.+?', '\\*' => '[^/]+?']);
+
+        // add support for up-level relative paths
+        $updir = null;
+        $path = preg_replace_callback(
+            '{^((?:(?:\\\\\\.){1,2}+/)+)}',
+            static function ($matches) use (&$updir): string {
+                if (isset($matches[1]) && $matches[1] !== '') {
+                    // undo preg_quote for the matched string
+                    $updir = str_replace('\\.', '.', $matches[1]);
+                }
+
+                return '';
+            },
+            $path
+            // note: composer also use `PREG_UNMATCHED_AS_NULL` but it is supported since PHP v7.4
+        );
+
+        if ($path === null) {
+            throw new InvalidPathException("Failure while globbing $pathPattern path.");
+        }
+
+        $resolvedPath = realpath($basePath . '/' . $updir);
+
+        if ($resolvedPath === false) {
+            throw new InvalidPathException("Failure while globbing $pathPattern path.");
+        }
+
+        // Finalize
+        $delimiter = '#';
+        $pattern = '^' . preg_quote(strtr($resolvedPath, '\\', '/'), $delimiter) . '/' . $path . '($|/)';
+        $pattern = $delimiter . $pattern . $delimiter;
+
+        return $pattern;
+    }
+
+    /**
      * @return array{
      *     require?: array<string, string>,
      *     require-dev?: array<string, string>,
@@ -136,13 +225,15 @@ class ComposerJson
      *          psr-0?: array<string, string|string[]>,
      *          psr-4?: array<string, string|string[]>,
      *          files?: string[],
-     *          classmap?: string[]
+     *          classmap?: string[],
+     *          exclude-from-classmap?: string[]
      *     },
      *     autoload-dev?: array{
      *          psr-0?: array<string, string|string[]>,
      *          psr-4?: array<string, string|string[]>,
      *          files?: string[],
-     *          classmap?: string[]
+     *          classmap?: string[],
+     *          exclude-from-classmap?: string[]
      *     }
      * }
      * @throws InvalidPathException

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -57,7 +57,7 @@ class Configuration
     /**
      * @var list<string>
      */
-    private $regexpsToExclude = [];
+    private $regexesToExclude = [];
 
     /**
      * @var array<string, list<ErrorType::*>>
@@ -209,13 +209,13 @@ class Configuration
     }
 
     /**
-     * @param list<string> $regexps
+     * @param list<string> $regexes
      * @return $this
      */
-    public function addRegexpsToExclude(array $regexps): self
+    public function addRegexesToExclude(array $regexes): self
     {
-        foreach ($regexps as $regexp) {
-            $this->addRegexpToExclude($regexp);
+        foreach ($regexes as $regex) {
+            $this->addRegexToExclude($regex);
         }
 
         return $this;
@@ -224,9 +224,9 @@ class Configuration
     /**
      * @return $this
      */
-    public function addRegexpToExclude(string $regexp): self
+    public function addRegexToExclude(string $regex): self
     {
-        $this->regexpsToExclude[] = $regexp;
+        $this->regexesToExclude[] = $regex;
         return $this;
     }
 
@@ -456,8 +456,8 @@ class Configuration
             }
         }
 
-        foreach ($this->regexpsToExclude as $regexpToExclude) {
-            if ((bool) preg_match($regexpToExclude, $filePath)) {
+        foreach ($this->regexesToExclude as $regexToExclude) {
+            if ((bool) preg_match($regexToExclude, $filePath)) {
                 return true;
             }
         }

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -57,7 +57,7 @@ class Configuration
     /**
      * @var list<string>
      */
-    private $regexesToExclude = [];
+    private $pathRegexesToExclude = [];
 
     /**
      * @var array<string, list<ErrorType::*>>
@@ -213,10 +213,10 @@ class Configuration
      * @return $this
      * @throws InvalidConfigException
      */
-    public function addRegexesToExclude(array $regexes): self
+    public function addPathRegexesToExclude(array $regexes): self
     {
         foreach ($regexes as $regex) {
-            $this->addRegexToExclude($regex);
+            $this->addPathRegexToExclude($regex);
         }
 
         return $this;
@@ -226,13 +226,13 @@ class Configuration
      * @return $this
      * @throws InvalidConfigException
      */
-    public function addRegexToExclude(string $regex): self
+    public function addPathRegexToExclude(string $regex): self
     {
         if (@preg_match($regex, '') === false) {
             throw new InvalidConfigException("Invalid regex '$regex'");
         }
 
-        $this->regexesToExclude[] = $regex;
+        $this->pathRegexesToExclude[] = $regex;
         return $this;
     }
 
@@ -462,8 +462,8 @@ class Configuration
             }
         }
 
-        foreach ($this->regexesToExclude as $regexToExclude) {
-            if ((bool) preg_match($regexToExclude, $filePath)) {
+        foreach ($this->pathRegexesToExclude as $pathRegexToExclude) {
+            if ((bool) preg_match($pathRegexToExclude, $filePath)) {
                 return true;
             }
         }

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -211,6 +211,7 @@ class Configuration
     /**
      * @param list<string> $regexes
      * @return $this
+     * @throws InvalidConfigException
      */
     public function addRegexesToExclude(array $regexes): self
     {
@@ -223,9 +224,14 @@ class Configuration
 
     /**
      * @return $this
+     * @throws InvalidConfigException
      */
     public function addRegexToExclude(string $regex): self
     {
+        if (@preg_match($regex, '') === false) {
+            throw new InvalidConfigException("Invalid regex '$regex'");
+        }
+
         $this->regexesToExclude[] = $regex;
         return $this;
     }

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -55,6 +55,11 @@ class Configuration
     private $pathsToExclude = [];
 
     /**
+     * @var list<string>
+     */
+    private $regexpsToExclude = [];
+
+    /**
      * @var array<string, list<ErrorType::*>>
      */
     private $ignoredErrorsOnPath = [];
@@ -200,6 +205,28 @@ class Configuration
     public function addPathToExclude(string $path): self
     {
         $this->pathsToExclude[] = Path::realpath($path);
+        return $this;
+    }
+
+    /**
+     * @param list<string> $regexps
+     * @return $this
+     */
+    public function addRegexpsToExclude(array $regexps): self
+    {
+        foreach ($regexps as $regexp) {
+            $this->addRegexpToExclude($regexp);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addRegexpToExclude(string $regexp): self
+    {
+        $this->regexpsToExclude[] = $regexp;
         return $this;
     }
 
@@ -425,6 +452,12 @@ class Configuration
     {
         foreach ($this->pathsToExclude as $pathToExclude) {
             if ($this->isFilepathWithinPath($filePath, $pathToExclude)) {
+                return true;
+            }
+        }
+
+        foreach ($this->regexpsToExclude as $regexpToExclude) {
+            if ((bool) preg_match($regexpToExclude, $filePath)) {
                 return true;
             }
         }

--- a/src/Initializer.php
+++ b/src/Initializer.php
@@ -147,7 +147,7 @@ EOD;
                 }
 
                 foreach ($composerJson->autoloadExcludeRegexes as $excludeRegex => $isDevRegex) {
-                    $config->addRegexToExclude($excludeRegex);
+                    $config->addPathRegexToExclude($excludeRegex);
                 }
             } catch (InvalidPathException $e) {
                 throw new InvalidConfigException('Error while processing composer.json autoload path: ' . $e->getMessage(), $e);

--- a/src/Initializer.php
+++ b/src/Initializer.php
@@ -145,6 +145,10 @@ EOD;
                 foreach ($composerJson->autoloadPaths as $absolutePath => $isDevPath) {
                     $config->addPathToScan($absolutePath, $isDevPath);
                 }
+
+                foreach ($composerJson->autoloadExcludeRegexps as $excludeRegexp => $isDevRegexp) {
+                    $config->addRegexpToExclude($excludeRegexp);
+                }
             } catch (InvalidPathException $e) {
                 throw new InvalidConfigException('Error while processing composer.json autoload path: ' . $e->getMessage(), $e);
             }

--- a/src/Initializer.php
+++ b/src/Initializer.php
@@ -146,8 +146,8 @@ EOD;
                     $config->addPathToScan($absolutePath, $isDevPath);
                 }
 
-                foreach ($composerJson->autoloadExcludeRegexps as $excludeRegexp => $isDevRegexp) {
-                    $config->addRegexpToExclude($excludeRegexp);
+                foreach ($composerJson->autoloadExcludeRegexes as $excludeRegex => $isDevRegex) {
+                    $config->addRegexToExclude($excludeRegex);
                 }
             } catch (InvalidPathException $e) {
                 throw new InvalidConfigException('Error while processing composer.json autoload path: ' . $e->getMessage(), $e);

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -215,8 +215,8 @@ class AnalyserTest extends TestCase
         yield 'scan dir, exclude regex' => [
             static function (Configuration $config) use ($variousUsagesPath): void {
                 $config->addPathToScan(dirname($variousUsagesPath), false);
-                $config->addRegexToExclude('/unknown/');
-                $config->addRegexesToExclude([
+                $config->addPathRegexToExclude('/unknown/');
+                $config->addPathRegexesToExclude([
                     '/^not match$/',
                 ]);
             },

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -212,6 +212,22 @@ class AnalyserTest extends TestCase
             ]),
         ];
 
+        yield 'scan dir, exclude regex' => [
+            static function (Configuration $config) use ($variousUsagesPath): void {
+                $config->addPathToScan(dirname($variousUsagesPath), false);
+                $config->addRegexToExclude('/unknown/');
+                $config->addRegexesToExclude([
+                    '/^not match$/',
+                ]);
+            },
+            $this->createAnalysisResult(1, [
+                ErrorType::UNKNOWN_CLASS => ['Unknown\Clazz' => [new SymbolUsage($variousUsagesPath, 11, SymbolKind::CLASSLIKE)]],
+                ErrorType::DEV_DEPENDENCY_IN_PROD => ['dev/package' => ['Dev\Package\Clazz' => [new SymbolUsage($variousUsagesPath, 16, SymbolKind::CLASSLIKE)]]],
+                ErrorType::SHADOW_DEPENDENCY => ['shadow/package' => ['Shadow\Package\Clazz' => [new SymbolUsage($variousUsagesPath, 24, SymbolKind::CLASSLIKE)]]],
+                ErrorType::UNUSED_DEPENDENCY => ['regular/dead'],
+            ]),
+        ];
+
         yield 'ignore on path' => [
             static function (Configuration $config) use ($variousUsagesPath, $unknownClassesPath): void {
                 $config->addPathToScan(dirname($variousUsagesPath), false);

--- a/tests/ComposerJsonTest.php
+++ b/tests/ComposerJsonTest.php
@@ -9,6 +9,7 @@ use function file_put_contents;
 use function json_encode;
 use function mkdir;
 use function realpath;
+use function str_replace;
 use function strtr;
 use function sys_get_temp_dir;
 use const DIRECTORY_SEPARATOR;
@@ -41,6 +42,20 @@ class ComposerJsonTest extends TestCase
                 realpath(__DIR__ . '/data/not-autoloaded/composer/dir2') => false,
             ],
             $composerJson->autoloadPaths
+        );
+
+        $replacements = [
+            '__DIR__' => str_replace(DIRECTORY_SEPARATOR, '/', __DIR__),
+        ];
+
+        self::assertSame(
+            [
+                strtr('#^__DIR__/data/not\-autoloaded/composer/dir2/[^/]+?\.php($|/)#', $replacements)    => false,
+                strtr('#^__DIR__/data/not\-autoloaded/composer/dir3/.+?/file1\.php($|/)#', $replacements) => false,
+                strtr('#^__DIR__/data/not\-autoloaded/composer/tests($|/)#', $replacements)               => false,
+                strtr('#^__DIR__/data/not\-autoloaded/composer/dir1/file1\.php($|/)#', $replacements)     => true,
+            ],
+            $composerJson->autoloadExcludeRegexps
         );
     }
 

--- a/tests/ComposerJsonTest.php
+++ b/tests/ComposerJsonTest.php
@@ -56,7 +56,7 @@ class ComposerJsonTest extends TestCase
                 strtr('#^__DIR__/data/not\-autoloaded/composer/tests($|/)#', $replacements)               => false,
                 strtr('#^__DIR__/data/not\-autoloaded/composer/dir1/file1\.php($|/)#', $replacements)     => true,
             ],
-            $composerJson->autoloadExcludeRegexps
+            $composerJson->autoloadExcludeRegexes
         );
     }
 

--- a/tests/ComposerJsonTest.php
+++ b/tests/ComposerJsonTest.php
@@ -8,6 +8,7 @@ use function dirname;
 use function file_put_contents;
 use function json_encode;
 use function mkdir;
+use function preg_quote;
 use function realpath;
 use function str_replace;
 use function strtr;
@@ -45,7 +46,7 @@ class ComposerJsonTest extends TestCase
         );
 
         $replacements = [
-            '__DIR__' => str_replace(DIRECTORY_SEPARATOR, '/', __DIR__),
+            '__DIR__' => preg_quote(str_replace(DIRECTORY_SEPARATOR, '/', __DIR__), '#'),
         ];
 
         self::assertSame(

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -260,7 +260,7 @@ class ConfigurationTest extends TestCase
     {
         $configuration = new Configuration();
         $configuration->addPathToExclude(__FILE__);
-        $configuration->addRegexpToExclude('{^/excluded$}');
+        $configuration->addRegexToExclude('{^/excluded$}');
 
         self::assertFalse($configuration->isExcludedFilepath(__DIR__));
         self::assertTrue($configuration->isExcludedFilepath(__FILE__));

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -244,7 +244,7 @@ class ConfigurationTest extends TestCase
 
         yield 'invalid regex to exclude' => [
             static function (Configuration $configuration): void {
-                $configuration->addRegexToExclude('~[~');
+                $configuration->addPathRegexToExclude('~[~');
             },
             "Invalid regex '~[~'",
         ];
@@ -267,7 +267,7 @@ class ConfigurationTest extends TestCase
     {
         $configuration = new Configuration();
         $configuration->addPathToExclude(__FILE__);
-        $configuration->addRegexToExclude('{^/excluded$}');
+        $configuration->addPathRegexToExclude('{^/excluded$}');
 
         self::assertFalse($configuration->isExcludedFilepath(__DIR__));
         self::assertTrue($configuration->isExcludedFilepath(__FILE__));

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -241,6 +241,13 @@ class ConfigurationTest extends TestCase
             },
             "Invalid regex '~[~'",
         ];
+
+        yield 'invalid regex to exclude' => [
+            static function (Configuration $configuration): void {
+                $configuration->addRegexToExclude('~[~');
+            },
+            "Invalid regex '~[~'",
+        ];
     }
 
     /**

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -256,6 +256,18 @@ class ConfigurationTest extends TestCase
         $configure($configuration);
     }
 
+    public function testIsExcludedFilepath(): void
+    {
+        $configuration = new Configuration();
+        $configuration->addPathToExclude(__FILE__);
+        $configuration->addRegexpToExclude('{^/excluded$}');
+
+        self::assertFalse($configuration->isExcludedFilepath(__DIR__));
+        self::assertTrue($configuration->isExcludedFilepath(__FILE__));
+        self::assertTrue($configuration->isExcludedFilepath('/excluded'));
+        self::assertFalse($configuration->isExcludedFilepath('/excluded/not/match'));
+    }
+
     /**
      * @return iterable<string, array{callable(Configuration): void, string}>
      */

--- a/tests/InitializerTest.php
+++ b/tests/InitializerTest.php
@@ -22,7 +22,7 @@ class InitializerTest extends TestCase
 
         $composerJson = $this->createMock(ComposerJson::class);
         $composerJson->autoloadPaths = [__DIR__ => false]; // @phpstan-ignore-line ignore readonly
-        $composerJson->autoloadExcludeRegexps = ['{^/excluded$}' => false]; // @phpstan-ignore-line ignore readonly
+        $composerJson->autoloadExcludeRegexes = ['{^/excluded$}' => false]; // @phpstan-ignore-line ignore readonly
 
         $options = new CliOptions();
         $options->ignoreUnknownClasses = true;

--- a/tests/InitializerTest.php
+++ b/tests/InitializerTest.php
@@ -22,6 +22,7 @@ class InitializerTest extends TestCase
 
         $composerJson = $this->createMock(ComposerJson::class);
         $composerJson->autoloadPaths = [__DIR__ => false]; // @phpstan-ignore-line ignore readonly
+        $composerJson->autoloadExcludeRegexps = ['{^/excluded$}' => false]; // @phpstan-ignore-line ignore readonly
 
         $options = new CliOptions();
         $options->ignoreUnknownClasses = true;

--- a/tests/InitializerTest.php
+++ b/tests/InitializerTest.php
@@ -22,7 +22,7 @@ class InitializerTest extends TestCase
 
         $composerJson = $this->createMock(ComposerJson::class);
         $composerJson->autoloadPaths = [__DIR__ => false]; // @phpstan-ignore-line ignore readonly
-        $composerJson->autoloadExcludeRegexes = ['{^/excluded$}' => false]; // @phpstan-ignore-line ignore readonly
+        $composerJson->autoloadExcludeRegexes = ['{/excluded}' => false, '{/excluded-dev}' => false]; // @phpstan-ignore-line ignore readonly
 
         $options = new CliOptions();
         $options->ignoreUnknownClasses = true;
@@ -33,6 +33,9 @@ class InitializerTest extends TestCase
         self::assertEquals([new PathToScan(__DIR__, false)], $config->getPathsToScan());
         self::assertTrue($config->getIgnoreList()->shouldIgnoreUnknownClass('Any', 'any'));
         self::assertFalse($config->getIgnoreList()->shouldIgnoreError(ErrorType::SHADOW_DEPENDENCY, null, null));
+        self::assertFalse($config->isExcludedFilepath(__DIR__ . '/not-excluded.php'));
+        self::assertTrue($config->isExcludedFilepath(__DIR__ . '/excluded.php'));
+        self::assertTrue($config->isExcludedFilepath(__DIR__ . '/excluded-dev.php'));
     }
 
     public function testInitComposerJson(): void

--- a/tests/data/not-autoloaded/composer/sample.json
+++ b/tests/data/not-autoloaded/composer/sample.json
@@ -12,6 +12,17 @@
         ],
         "files": [
             "dir2/file1.php"
+        ],
+        "exclude-from-classmap": [
+            "/dir2///*.php",
+            "/dir3/**/file1.php",
+            "/tests/",
+            "../composer///dir1/file1.php"
+        ]
+    },
+    "autoload-dev": {
+        "exclude-from-classmap": [
+            "/dir1/file1.php"
         ]
     },
     "config": {


### PR DESCRIPTION
* Patterns will be converted into regexps the same as composer do
* `ComposerJson` stores `exclude-from-classmap` separately for prod/dev, but this information is unused now
* `Configuration` now can exclude files by regexps
* All `exclude-from-classmap` patterns will be added as exclusions (this may be a breaking/unexpected change)

Closes: #136