### PR TITLE
[Fix] unmatched qualified name ::class|const|function

### DIFF
--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -28,6 +28,17 @@ class UsedSymbolExtractorTest extends TestCase
      */
     public function provideVariants(): iterable
     {
+        yield 'qualified named' => [
+            __DIR__ . '/data/not-autoloaded/used-symbols/qualified-named.php',
+            [
+                SymbolKind::CLASSLIKE => [
+                    'Foo\Bar' => [4, 12, 15, 19],
+                    'Foo2\Baz' => [6, 17, 20, 21],
+                    'Foo2\Bar' => [24],
+                ],
+            ],
+        ];
+
         yield 'use statements' => [
             __DIR__ . '/data/not-autoloaded/used-symbols/use-statements.php',
             [

--- a/tests/data/not-autoloaded/used-symbols/qualified-named.php
+++ b/tests/data/not-autoloaded/used-symbols/qualified-named.php
@@ -1,0 +1,24 @@
+<?php
+
+// Qualified name without use statement
+echo Foo\Bar::class;
+echo Foo2\Baz::MY_CONST;
+echo Foo2\Baz::my_function();
+
+echo Foo\Bar//com
+::class;
+echo Foo2\Baz//com
+::MY_CONST;
+echo Foo2\Baz//com
+::my_function();
+
+echo Foo\Bar/*com*/::class;
+echo Foo2\Baz/*com*/::MY_CONST;
+echo Foo2\Baz/*com*/::my_function();
+
+echo Foo\Bar/**doccom*/::class;
+echo Foo2\Baz/**doccom*/::MY_CONST;
+echo Foo2\Baz/**doccom*/::my_function();
+
+// Fully qualified
+echo \Foo2\Bar::class;


### PR DESCRIPTION
Hi,
i Discover this cool project yesterday, so i used it on a Symfony project.
And the result of unused dependencies seems to fail matching the `qualified name` like in [this file](https://github.com/symfony/demo/blob/main/config/bundles.php) 

so the purpose of this PR is to match the qualified name syntax
the new matching rule is 
`T_NAME_QUALIFIED(T_COMMENT, T_DOC_COMMENT)*T_DOUBLE_COLON`
`T_NAME_QUALIFIED` follow by next active token(not commented ones) `T_DOUBLE_COLON`

see the `UsedSymbolExtractor::isNextActiveTokenType` function to match this one

```php
// Qualified name without use statement
echo Foo\Bar::class;
echo Foo2\Baz::MY_CONST;
echo Foo2\Baz::my_function();

echo Foo\Bar//com
::class;
echo Foo2\Baz//com
::MY_CONST;
echo Foo2\Baz//com
::my_function();

echo Foo\Bar/*com*/::class;
echo Foo2\Baz/*com*/::MY_CONST;
echo Foo2\Baz/*com*/::my_function();

echo Foo\Bar/**doccom*/::class;
echo Foo2\Baz/**doccom*/::MY_CONST;
echo Foo2\Baz/**doccom*/::my_function();
```

I hope my contribution was clean and useful.

Have a nice coding day 👨🏻‍💻
