### PR TITLE
Support absolute paths in composer autoload sections

### DIFF
--- a/src/ComposerJson.php
+++ b/src/ComposerJson.php
@@ -128,7 +128,11 @@ class ComposerJson
             }
 
             foreach ($paths as $path) {
-                $absolutePath = $basePath . '/' . $path;
+                if (strpos($path, '/') === 0) {
+                    $absolutePath = $path;
+                } else {
+                    $absolutePath = $basePath . '/' . $path;
+                }
 
                 if (strpos($path, '*') !== false) { // https://getcomposer.org/doc/04-schema.md#classmap
                     $globPaths = glob($absolutePath);

--- a/src/ComposerJson.php
+++ b/src/ComposerJson.php
@@ -128,7 +128,7 @@ class ComposerJson
             }
 
             foreach ($paths as $path) {
-                if (strpos($path, '/') === 0) {
+                if (Path::isAbsolute($path)) {
                     $absolutePath = $path;
                 } else {
                     $absolutePath = $basePath . '/' . $path;

--- a/tests/ComposerJsonTest.php
+++ b/tests/ComposerJsonTest.php
@@ -41,6 +41,7 @@ class ComposerJsonTest extends TestCase
                 realpath(__DIR__ . '/data/not-autoloaded/composer/dir2/file1.php') => false,
                 realpath(__DIR__ . '/data/not-autoloaded/composer/dir1') => false,
                 realpath(__DIR__ . '/data/not-autoloaded/composer/dir2') => false,
+                '/absolute/dir' => false,
             ],
             $composerJson->autoloadPaths
         );

--- a/tests/ComposerJsonTest.php
+++ b/tests/ComposerJsonTest.php
@@ -41,7 +41,7 @@ class ComposerJsonTest extends TestCase
                 realpath(__DIR__ . '/data/not-autoloaded/composer/dir2/file1.php') => false,
                 realpath(__DIR__ . '/data/not-autoloaded/composer/dir1') => false,
                 realpath(__DIR__ . '/data/not-autoloaded/composer/dir2') => false,
-                '/absolute/dir' => false,
+                DIRECTORY_SEPARATOR . 'absolute' . DIRECTORY_SEPARATOR . 'dir' => false,
             ],
             $composerJson->autoloadPaths
         );

--- a/tests/data/not-autoloaded/composer/sample.json
+++ b/tests/data/not-autoloaded/composer/sample.json
@@ -8,7 +8,8 @@
     },
     "autoload": {
         "classmap": [
-            "dir*"
+            "dir*",
+            "/absolute/dir"
         ],
         "files": [
             "dir2/file1.php"


### PR DESCRIPTION
Hi @janedbal,

I recently tried your lib and it's really great.

I just encounter an issue, when I use an absolute path in my `autoload.classmap` key of the composer.json, this lib consider it's a relative path when composer does resolve the absolute path. I made some checks and
- `/src` is not found by composer (but does by your lib), so it means that composer don't have a relative-path fallback when the absolute is not found. It just respect my path.
- `/my-absolute-path` is found by composer (but not your lib)

I made a fix to respect absolute path given and updated the tests.