### PR TITLE
Remove reserved exit code 255 and replace it with exit code 1

### DIFF
--- a/bin/composer-dependency-analyser
+++ b/bin/composer-dependency-analyser
@@ -53,7 +53,7 @@ try {
     InvalidCliException $e
 ) {
     $stdErrPrinter->printLine("\n<red>{$e->getMessage()}</red>" . PHP_EOL);
-    exit(255);
+    exit(1);
 
 } catch (AbortException $e) {
     exit(0);

--- a/src/Result/ConsoleFormatter.php
+++ b/src/Result/ConsoleFormatter.php
@@ -211,7 +211,7 @@ class ConsoleFormatter implements ResultFormatter
 
         $this->printRunSummary($result);
 
-        return $hasError ? 255 : 0;
+        return $hasError ? 1 : 0;
     }
 
     /**

--- a/src/Result/JunitFormatter.php
+++ b/src/Result/JunitFormatter.php
@@ -131,7 +131,7 @@ class JunitFormatter implements ResultFormatter
         $this->printer->print($this->prettyPrintXml($xml));
 
         if ($hasError) {
-            return 255;
+            return 1;
         }
 
         return 0;

--- a/tests/BinTest.php
+++ b/tests/BinTest.php
@@ -32,19 +32,19 @@ class BinTest extends TestCase
 
         $this->runCommand('php bin/composer-dependency-analyser', $rootDir, 0, $okOutput, $usingConfig);
         $this->runCommand('php bin/composer-dependency-analyser --verbose', $rootDir, 0, $okOutput, $usingConfig);
-        $this->runCommand('php ../bin/composer-dependency-analyser', $testsDir, 255, null, $noComposerJsonError);
+        $this->runCommand('php ../bin/composer-dependency-analyser', $testsDir, 1, null, $noComposerJsonError);
         $this->runCommand('php bin/composer-dependency-analyser --help', $rootDir, 0, $helpOutput);
         $this->runCommand('php ../bin/composer-dependency-analyser --help', $testsDir, 0, $helpOutput);
         $this->runCommand('php ../bin/composer-dependency-analyser --version', $testsDir, 0, $versionOutput);
         $this->runCommand('php bin/composer-dependency-analyser --composer-json=composer.json', $rootDir, 0, $okOutput, $usingConfig);
-        $this->runCommand('php bin/composer-dependency-analyser --composer-json=composer.lock', $rootDir, 255, null, $noPackagesError);
-        $this->runCommand('php bin/composer-dependency-analyser --composer-json=README.md', $rootDir, 255, null, $parseError);
-        $this->runCommand('php ../bin/composer-dependency-analyser --composer-json=composer.json', $testsDir, 255, null, $noComposerJsonError);
+        $this->runCommand('php bin/composer-dependency-analyser --composer-json=composer.lock', $rootDir, 1, null, $noPackagesError);
+        $this->runCommand('php bin/composer-dependency-analyser --composer-json=README.md', $rootDir, 1, null, $parseError);
+        $this->runCommand('php ../bin/composer-dependency-analyser --composer-json=composer.json', $testsDir, 1, null, $noComposerJsonError);
         $this->runCommand('php ../bin/composer-dependency-analyser --composer-json=../composer.json --config=../composer-dependency-analyser.php', $testsDir, 0, $okOutput, $usingConfig);
         $this->runCommand('php bin/composer-dependency-analyser --composer-json=composer.json --format=console', $rootDir, 0, $okOutput, $usingConfig);
         $this->runCommand('php bin/composer-dependency-analyser --composer-json=composer.json --format=console --dump-usages=symfony/*', $rootDir, 1, $dumpingOutput, $usingConfig);
         $this->runCommand('php bin/composer-dependency-analyser --composer-json=composer.json --format=junit', $rootDir, 0, $junitOutput, $usingConfig);
-        $this->runCommand('php bin/composer-dependency-analyser --composer-json=composer.json --format=junit --dump-usages=symfony/*', $rootDir, 255, null, $junitDumpError);
+        $this->runCommand('php bin/composer-dependency-analyser --composer-json=composer.json --format=junit --dump-usages=symfony/*', $rootDir, 1, null, $junitDumpError);
     }
 
     private function runCommand(


### PR DESCRIPTION
Exit code 255 is reserved by PHP: https://www.php.net/manual/en/function.exit.php

>   Note: Exit codes should be in the range 0 to 254, the exit code 255 is reserved by PHP and should not be used. 

While there is no definitive standard on exit codes, 255 is also generally reserved, see the [linux documentation project (unofficial source) ](https://tldp.org/LDP/abs/html/exitcodes.html)

This PR removes all usages of exit 255 and replaces it with exit code 1, in line with the changes in #110 where exit code 1 was already used for errors in the JUnitFormatter. Using exit codes 0 and 1 is also in line with [symfony console](https://github.com/symfony/symfony/pull/35478/files) and tools like [composer](https://getcomposer.org/doc/03-cli.md#process-exit-codes) and PHPStan. 