### PR TITLE
Introduce detection of dev source code used in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ This tool reads your `composer.json` and scans all paths listed in `autoload` & 
   - For applications, it can break once you run it with `composer install --no-dev`
   - You should move those from `require-dev` to `require`
 
+### Dev source code used in production
+  - Detects when production code imports classes from dev-only autoload paths (e.g., `src-dev/`, `tests/`)
+  - This happens when the same namespace is mapped to both production and dev paths
+  - Can cause runtime failures when dev directories are excluded from deployment
+  - You should either move the used classes to production paths or refactor your code
+
 ### Prod dependencies used only in dev paths
   - For libraries, this miscategorization can lead to uselessly required dependencies for your users
   - You should move those from `require` to `require-dev`

--- a/bin/composer-dependency-analyser
+++ b/bin/composer-dependency-analyser
@@ -41,7 +41,7 @@ try {
     $configuration = $initializer->initConfiguration($options, $composerJson);
     $classLoaders = $initializer->initComposerClassLoaders();
 
-    $analyser = new Analyser($stopwatch, $composerJson->composerVendorDir, $classLoaders, $configuration, $composerJson->dependencies);
+    $analyser = new Analyser($stopwatch, $composerJson->composerVendorDir, $classLoaders, $configuration, $composerJson->dependencies, $composerJson->autoloadPaths);
     $result = $analyser->run();
 
     $formatter = $initializer->initFormatter($options);

--- a/src/Config/ErrorType.php
+++ b/src/Config/ErrorType.php
@@ -10,6 +10,7 @@ final class ErrorType
     public const SHADOW_DEPENDENCY = 'shadow-dependency';
     public const UNUSED_DEPENDENCY = 'unused-dependency';
     public const DEV_DEPENDENCY_IN_PROD = 'dev-dependency-in-prod';
+    public const DEV_SOURCE_IN_PROD = 'dev-source-in-prod';
     public const PROD_DEPENDENCY_ONLY_IN_DEV = 'prod-dependency-only-in-dev';
 
 }

--- a/src/Config/Ignore/IgnoreList.php
+++ b/src/Config/Ignore/IgnoreList.php
@@ -238,7 +238,7 @@ class IgnoreList
     }
 
     /**
-     * @param ErrorType::SHADOW_DEPENDENCY|ErrorType::UNUSED_DEPENDENCY|ErrorType::DEV_DEPENDENCY_IN_PROD|ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV $errorType
+     * @param ErrorType::SHADOW_DEPENDENCY|ErrorType::UNUSED_DEPENDENCY|ErrorType::DEV_DEPENDENCY_IN_PROD|ErrorType::DEV_SOURCE_IN_PROD|ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV $errorType
      */
     public function shouldIgnoreError(string $errorType, ?string $realPath, ?string $dependency): bool
     {

--- a/src/Result/AnalysisResult.php
+++ b/src/Result/AnalysisResult.php
@@ -46,6 +46,11 @@ class AnalysisResult
     private $devDependencyInProductionErrors = [];
 
     /**
+     * @var array<string, array<string, list<SymbolUsage>>>
+     */
+    private $devSourceInProductionErrors = [];
+
+    /**
      * @var list<string>
      */
     private $prodDependencyOnlyInDevErrors;
@@ -66,6 +71,7 @@ class AnalysisResult
      * @param array<string, list<SymbolUsage>> $unknownFunctionErrors package => usages
      * @param array<string, array<string, list<SymbolUsage>>> $shadowDependencyErrors package => [ classname => usage[] ]
      * @param array<string, array<string, list<SymbolUsage>>> $devDependencyInProductionErrors package => [ classname => usage[] ]
+     * @param array<string, array<string, list<SymbolUsage>>> $devSourceInProductionErrors dev-source => [ classname => usage[] ]
      * @param list<string> $prodDependencyOnlyInDevErrors package[]
      * @param list<string> $unusedDependencyErrors package[]
      * @param list<UnusedSymbolIgnore|UnusedErrorIgnore> $unusedIgnores
@@ -78,6 +84,7 @@ class AnalysisResult
         array $unknownFunctionErrors,
         array $shadowDependencyErrors,
         array $devDependencyInProductionErrors,
+        array $devSourceInProductionErrors,
         array $prodDependencyOnlyInDevErrors,
         array $unusedDependencyErrors,
         array $unusedIgnores
@@ -88,6 +95,7 @@ class AnalysisResult
         ksort($unknownFunctionErrors);
         ksort($shadowDependencyErrors);
         ksort($devDependencyInProductionErrors);
+        ksort($devSourceInProductionErrors);
         sort($prodDependencyOnlyInDevErrors);
         sort($unusedDependencyErrors);
 
@@ -109,6 +117,11 @@ class AnalysisResult
         foreach ($devDependencyInProductionErrors as $package => $classes) {
             ksort($classes);
             $this->devDependencyInProductionErrors[$package] = $classes;
+        }
+
+        foreach ($devSourceInProductionErrors as $devSource => $classes) {
+            ksort($classes);
+            $this->devSourceInProductionErrors[$devSource] = $classes;
         }
 
         $this->prodDependencyOnlyInDevErrors = $prodDependencyOnlyInDevErrors;
@@ -164,6 +177,14 @@ class AnalysisResult
     public function getDevDependencyInProductionErrors(): array
     {
         return $this->devDependencyInProductionErrors;
+    }
+
+    /**
+     * @return array<string, array<string, list<SymbolUsage>>>
+     */
+    public function getDevSourceInProductionErrors(): array
+    {
+        return $this->devSourceInProductionErrors;
     }
 
     /**

--- a/src/Result/ConsoleFormatter.php
+++ b/src/Result/ConsoleFormatter.php
@@ -121,6 +121,7 @@ class ConsoleFormatter implements ResultFormatter
         $unknownFunctionErrors = $result->getUnknownFunctionErrors();
         $shadowDependencyErrors = $result->getShadowDependencyErrors();
         $devDependencyInProductionErrors = $result->getDevDependencyInProductionErrors();
+        $devSourceInProductionErrors = $result->getDevSourceInProductionErrors();
         $prodDependencyOnlyInDevErrors = $result->getProdDependencyOnlyInDevErrors();
         $unusedDependencyErrors = $result->getUnusedDependencyErrors();
 
@@ -128,6 +129,7 @@ class ConsoleFormatter implements ResultFormatter
         $unknownFunctionErrorsCount = count($unknownFunctionErrors);
         $shadowDependencyErrorsCount = count($shadowDependencyErrors);
         $devDependencyInProductionErrorsCount = count($devDependencyInProductionErrors);
+        $devSourceInProductionErrorsCount = count($devSourceInProductionErrors);
         $prodDependencyOnlyInDevErrorsCount = count($prodDependencyOnlyInDevErrors);
         $unusedDependencyErrorsCount = count($unusedDependencyErrors);
 
@@ -171,6 +173,17 @@ class ConsoleFormatter implements ResultFormatter
                 "Found $devDependencyInProductionErrorsCount dev $dependencies in production code!",
                 'those should probably be moved to "require" section in composer.json',
                 $devDependencyInProductionErrors,
+                $maxShownUsages
+            );
+        }
+
+        if ($devSourceInProductionErrorsCount > 0) {
+            $hasError = true;
+            $sources = $this->pluralize($devSourceInProductionErrorsCount, 'dev source');
+            $this->printPackageBasedErrors(
+                "Found $devSourceInProductionErrorsCount $sources used in production code!",
+                'source code from autoload-dev paths should not be used in production',
+                $devSourceInProductionErrors,
                 $maxShownUsages
             );
         }

--- a/tests/ConsoleFormatterTest.php
+++ b/tests/ConsoleFormatterTest.php
@@ -17,10 +17,10 @@ class ConsoleFormatterTest extends FormatterTestCase
     {
         // editorconfig-checker-disable
         $noIssuesOutput = $this->getFormatterNormalizedOutput(static function (ResultFormatter $formatter): void {
-            $formatter->format(new AnalysisResult(2, 0.123, [], [], [], [], [], [], [], []), new CliOptions(), new Configuration());
+            $formatter->format(new AnalysisResult(2, 0.123, [], [], [], [], [], [], [], [], []), new CliOptions(), new Configuration());
         });
         $noIssuesButUnusedIgnores = $this->getFormatterNormalizedOutput(static function (ResultFormatter $formatter): void {
-            $formatter->format(new AnalysisResult(2, 0.123, [], [], [], [], [], [], [], [new UnusedErrorIgnore(ErrorType::SHADOW_DEPENDENCY, null, null)]), new CliOptions(), new Configuration());
+            $formatter->format(new AnalysisResult(2, 0.123, [], [], [], [], [], [], [], [], [new UnusedErrorIgnore(ErrorType::SHADOW_DEPENDENCY, null, null)]), new CliOptions(), new Configuration());
         });
 
         $expectedNoIssuesOutput = <<<'OUT'
@@ -67,6 +67,7 @@ OUT;
                 ],
             ],
             ['some/package' => ['Another\Command' => [new SymbolUsage('/app/src/ProductGenerator.php', 28, SymbolKind::CLASSLIKE)]]],
+            [],
             ['misplaced/package'],
             ['dead/package'],
             []

--- a/tests/JunitFormatterTest.php
+++ b/tests/JunitFormatterTest.php
@@ -17,10 +17,10 @@ class JunitFormatterTest extends FormatterTestCase
     {
         // editorconfig-checker-disable
         $noIssuesOutput = $this->getFormatterNormalizedOutput(static function (ResultFormatter $formatter): void {
-            $formatter->format(new AnalysisResult(2, 0.123, [], [], [], [], [], [], [], []), new CliOptions(), new Configuration());
+            $formatter->format(new AnalysisResult(2, 0.123, [], [], [], [], [], [], [], [], []), new CliOptions(), new Configuration());
         });
         $noIssuesButUnusedIgnores = $this->getFormatterNormalizedOutput(static function (ResultFormatter $formatter): void {
-            $formatter->format(new AnalysisResult(2, 0.123, [], [], [], [], [], [], [], [new UnusedErrorIgnore(ErrorType::SHADOW_DEPENDENCY, null, null)]), new CliOptions(), new Configuration());
+            $formatter->format(new AnalysisResult(2, 0.123, [], [], [], [], [], [], [], [], [new UnusedErrorIgnore(ErrorType::SHADOW_DEPENDENCY, null, null)]), new CliOptions(), new Configuration());
         });
 
         $expectedNoIssuesOutput = <<<'OUT'
@@ -69,6 +69,7 @@ OUT;
                 ],
             ],
             ['some/package' => ['Another\Command' => [new SymbolUsage('/app/src/ProductGenerator.php', 28, SymbolKind::CLASSLIKE)]]],
+            [],
             ['misplaced/package'],
             ['dead/package'],
             []

--- a/tests/data/not-autoloaded/dev-source-in-prod/src-dev/DevOnlyClass.php
+++ b/tests/data/not-autoloaded/dev-source-in-prod/src-dev/DevOnlyClass.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace App;
+
+class DevOnlyClass
+{
+    public function devOnlyMethod(): string
+    {
+        return 'This is only available in dev';
+    }
+}

--- a/tests/data/not-autoloaded/dev-source-in-prod/src/ProductionClass.php
+++ b/tests/data/not-autoloaded/dev-source-in-prod/src/ProductionClass.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace App;
+
+use App\DevOnlyClass;
+
+class ProductionClass
+{
+    public function useDevClass(): void
+    {
+        $devClass = new DevOnlyClass();
+        $devClass->devOnlyMethod();
+    }
+}


### PR DESCRIPTION
This adds a new error type `DEV_SOURCE_IN_PROD` that detects when production code imports classes from dev-only autoload paths.

This prevents runtime failures when for example these dev directories are left out of the deployment to production.

The feature detects cases like:
- Production code in `src/` importing from `src-dev/`
- Production code importing from `tests/` directory

Users can ignore these errors using:
```php
$config->ignoreErrorsOnPackage('src-dev', [ErrorType::DEV_SOURCE_IN_PROD]);
```