### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+                php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
                 operating-system: [ ubuntu-latest, windows-latest ]
         steps:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - ⚙️ **Configurable:** Fine-grained ignores via PHP config
 - 🕸️ **Lightweight:** No composer dependencies
 - 🍰 **Easy-to-use:** No config needed for first try
-- ✨ **Compatible:** PHP 7.2 - 8.4
+- ✨ **Compatible:** PHP 7.2 - 8.5
 
 ## Comparison:
 
@@ -179,5 +179,5 @@ NO_COLOR=1 vendor/bin/composer-dependency-analyser
 - All functionality must be tested
 
 ## Supported PHP versions
-- Runtime requires PHP 7.2 - 8.4
+- Runtime requires PHP 7.2 - 8.5
 - Scanned codebase should use PHP >= 5.3


### PR DESCRIPTION
## Summary

- Add PHP 8.5 to the CI test matrix in GitHub Actions
- Update README.md to reflect PHP 8.5 compatibility (both in features list and supported versions section)

Note: The `composer.json` constraint `^8.0` already covers PHP 8.5, so no changes needed there.

## Test plan

- [x] CI passes on all PHP versions including 8.5