### PR TITLE
Fix class/interface/trait/enum definitions being detected as function usages

### DIFF
--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -422,6 +422,10 @@ class UsedSymbolExtractor
             || $tokenBeforeName[0] === T_FUNCTION
             || $tokenBeforeName[0] === T_OBJECT_OPERATOR
             || $tokenBeforeName[0] === T_NAMESPACE
+            || $tokenBeforeName[0] === T_CLASS
+            || $tokenBeforeName[0] === T_INTERFACE
+            || $tokenBeforeName[0] === T_TRAIT
+            || $tokenBeforeName[0] === (PHP_VERSION_ID >= 80100 ? T_ENUM : -1)
             || $tokenBeforeName[0] === (PHP_VERSION_ID > 80000 ? T_NULLSAFE_OBJECT_OPERATOR : -1)
             || $tokenAfterName[0] === T_INSTEADOF
             || $tokenAfterName[0] === T_AS

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -60,6 +60,10 @@ class UsedSymbolExtractorTest extends TestCase
             [
                 strtolower('PDO') => SymbolKind::CLASSLIKE,
                 strtolower('SESSION_ID') => SymbolKind::CONSTANT,
+                // https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/216
+                strtolower('value') => SymbolKind::FUNCTION,
+                strtolower('collect') => SymbolKind::FUNCTION,
+                strtolower('tap') => SymbolKind::FUNCTION,
             ],
         ];
 

--- a/tests/data/not-autoloaded/used-symbols/t-string-issues.php
+++ b/tests/data/not-autoloaded/used-symbols/t-string-issues.php
@@ -24,3 +24,9 @@ class Test
     }
 
 }
+
+// https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/216
+// Class/interface/trait/enum definition names must not be detected as function usages
+class Value {}
+interface Collect {}
+trait Tap {}


### PR DESCRIPTION
## Summary
- Fixes false-positive shadow dependency when a class is defined with a name matching a known global function
- Added `T_CLASS`, `T_INTERFACE`, `T_TRAIT`, and `T_ENUM` checks to `canBeSymbolName()` to prevent class-like definition names from being processed as symbol usages

## Test plan
- [x] Added test case with `class Value {}`, `interface Collect {}`, `trait Tap {}` where `value`, `collect`, `tap` are known functions
- [x] All existing tests pass
- [x] PHPStan passes

Fixes #216