### PR TITLE
Detect unqualified function calls to allow unknown function reporting

### DIFF
--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -169,6 +169,18 @@ class UsedSymbolExtractor
                             }
 
                             $usedSymbols[$kind][$symbolName][] = $token[2];
+
+                        } elseif (
+                            $this->getTokenAfter($pointerAfterName) === '('
+                            && $this->getTokenBefore($pointerBeforeName)[0] !== T_NEW
+                        ) {
+                            // unqualified function call - register to allow detection of unknown functions
+                            // but skip 'set' and 'get' in PHP 8.4+ property hooks (preceded by '{' inside a class)
+                            if ($inClassLevel !== null && ($lowerName === 'set' || $lowerName === 'get') && $this->getTokenBefore($pointerBeforeName) === '{') {
+                                break;
+                            }
+
+                            $usedSymbols[SymbolKind::FUNCTION][$name][] = $token[2];
                         }
 
                         break;
@@ -235,6 +247,19 @@ class UsedSymbolExtractor
                                 $symbolName = $name;
                                 $kind = $this->getFqnSymbolKind($pointerBeforeName, $pointerAfterName, false);
                                 $usedSymbols[$kind][$symbolName][] = $token[2];
+
+                            } elseif (
+                                strpos($name, '\\') === false
+                                && $this->getTokenAfter($pointerAfterName) === '('
+                                && $this->getTokenBefore($pointerBeforeName)[0] !== T_NEW
+                            ) {
+                                // unqualified function call - register to allow detection of unknown functions
+                                // but skip 'set' and 'get' in PHP 8.4+ property hooks (preceded by '{' inside a class)
+                                if ($inClassLevel !== null && ($lowerName === 'set' || $lowerName === 'get') && $this->getTokenBefore($pointerBeforeName) === '{') {
+                                    break;
+                                }
+
+                                $usedSymbols[SymbolKind::FUNCTION][$name][] = $token[2];
                             }
                         }
 

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -150,6 +150,7 @@ class UsedSymbolExtractorTest extends TestCase
                     'DDTrace\root_span' => [13],
                     'DDTrace\Integrations\Exec\proc_get_pid' => [16],
                     'json_decode' => [21],
+                    'foo' => [25],
                 ],
                 SymbolKind::CONSTANT => [
                     'LIBXML_ERR_FATAL' => [9],
@@ -189,6 +190,18 @@ class UsedSymbolExtractorTest extends TestCase
             self::extensionSymbolsForExtensionsTestCases(),
         ];
 
+        // https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/222
+        yield 'unqualified function' => [
+            __DIR__ . '/data/not-autoloaded/used-symbols/unqualified-function.php',
+            [
+                SymbolKind::FUNCTION => [
+                    'not_reported_or_defined' => [9],
+                    'reported_and_not_defined' => [10],
+                    'also_reported_and_not_defined' => [11],
+                ],
+            ],
+        ];
+
         if (PHP_VERSION_ID >= 80000) {
             yield 'attribute' => [
                 __DIR__ . '/data/not-autoloaded/used-symbols/attribute.php',
@@ -205,7 +218,11 @@ class UsedSymbolExtractorTest extends TestCase
         if (PHP_VERSION_ID >= 80400) {
             yield 'property hooks' => [
                 __DIR__ . '/data/not-autoloaded/used-symbols/property-hooks.php',
-                [],
+                [
+                    SymbolKind::FUNCTION => [
+                        'strtolower' => [15],
+                    ],
+                ],
             ];
         }
     }

--- a/tests/data/not-autoloaded/used-symbols/unqualified-function.php
+++ b/tests/data/not-autoloaded/used-symbols/unqualified-function.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Test;
+
+use function also_reported_and_not_defined;
+
+// https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/222
+not_reported_or_defined();
+\reported_and_not_defined();
+also_reported_and_not_defined();


### PR DESCRIPTION
## Summary
- Fixes inconsistent detection of undefined functions where unqualified function calls (without `\` prefix or `use` statement) were silently ignored
- Now such calls are detected and passed to the Analyser, which can then report them as unknown functions
- Added filtering for PHP 8.4 property hooks to avoid false positives where `set` and `get` keywords were incorrectly detected as function calls

## Example
```php
<?php
namespace Test;

use function also_reported_and_not_defined;

not_reported_or_defined();      // NOW detected (was missing before)
\reported_and_not_defined();    // already detected
also_reported_and_not_defined(); // already detected
```

## Test plan
- [x] Added test case for unqualified function detection
- [x] Updated existing tests to reflect the new correct behavior
- [x] All tests pass
- [x] PHPStan passes

Fixes #222