### PR TITLE
Detect unqualified static access in global scope

### DIFF
--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -169,6 +169,14 @@ class UsedSymbolExtractor
                             }
 
                             $usedSymbols[$kind][$symbolName][] = $token[2];
+
+                        } elseif (
+                            $inGlobalScope
+                            && $this->getTokenAfter($pointerAfterName)[0] === T_DOUBLE_COLON
+                        ) {
+                            // unqualified static access (e.g., Foo::class, Foo::method(), Foo::CONSTANT) in global scope
+                            // register to allow detection of classes not in $knownSymbols
+                            $usedSymbols[SymbolKind::CLASSLIKE][$name][] = $token[2];
                         }
 
                         break;
@@ -235,6 +243,15 @@ class UsedSymbolExtractor
                                 $symbolName = $name;
                                 $kind = $this->getFqnSymbolKind($pointerBeforeName, $pointerAfterName, false);
                                 $usedSymbols[$kind][$symbolName][] = $token[2];
+
+                            } elseif (
+                                strpos($name, '\\') === false
+                                && $inGlobalScope
+                                && $this->getTokenAfter($pointerAfterName)[0] === T_DOUBLE_COLON
+                            ) {
+                                // unqualified static access (e.g., Foo::class, Foo::method(), Foo::CONSTANT) in global scope
+                                // register to allow detection of classes not in $knownSymbols
+                                $usedSymbols[SymbolKind::CLASSLIKE][$name][] = $token[2];
                             }
                         }
 

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -129,6 +129,9 @@ class UsedSymbolExtractorTest extends TestCase
                 SymbolKind::CLASSLIKE => [
                     'DateTimeImmutable' => [3],
                     'PHPUnit\Framework\Error' => [5],
+                    'UnknownClass' => [17, 18, 19], // issue #224: unqualified static access in global scope
+                    'self' => [22], // filtered by Analyser via ignoredSymbols
+                    'parent' => [24], // filtered by Analyser via ignoredSymbols
                 ],
                 SymbolKind::FUNCTION => [
                     'PHPUnit\Framework\assertSame' => [7],
@@ -188,6 +191,7 @@ class UsedSymbolExtractorTest extends TestCase
                     'PDO' => [11],
                     'My\App\XMLReader' => [15],
                     'CURLOPT_SSL_VERIFYHOST' => [19],
+                    'ZipArchive' => [22], // issue #224: now detected via unqualified static access
                 ],
             ],
             self::extensionSymbolsForExtensionsTestCases(),

--- a/tests/data/not-autoloaded/used-symbols/global-namespace.php
+++ b/tests/data/not-autoloaded/used-symbols/global-namespace.php
@@ -12,3 +12,13 @@ class Foo {
         user_defined_function();
     }
 }
+
+// Test for issue #224: unqualified static access in global scope
+$class = UnknownClass::class;
+UnknownClass::staticMethod();
+UnknownClass::CONSTANT;
+
+// These should NOT be detected as class usages
+self::FOO;
+static::bar();
+parent::__construct();


### PR DESCRIPTION
## Summary
- Fixes #224
- Detects classes used with static access patterns like `Foo::class`, `Foo::method()`, or `Foo::CONSTANT` in global scope when the class is not in `$knownSymbols`
- This affects **all static access patterns**, not just `::class`

## Problem
When using code like:
```php
<?php
// no namespace, no use statement
$class = ThInCacheInterface::class;
```

If `ThInCacheInterface` was not in `$knownSymbols`, it would not be detected as a class usage. This caused packages to be incorrectly flagged as "unused dependencies".

## Solution
Added detection for unqualified class names followed by `::` in global scope, similar to the existing handling for unqualified function calls.

## Test plan
- [x] Added test cases for `::class`, `::staticMethod()`, and `::CONSTANT` patterns in `global-namespace.php`
- [x] Updated `extensions-global.php` expectations for `ZipArchive::class` which is now detected
- [x] All existing tests pass
- [x] `composer check` passes