### PR TITLE
Fix keywords used as constant names resetting parser state

### DIFF
--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -91,7 +91,10 @@ class UsedSymbolExtractor
                 case T_INTERFACE:
                 case T_TRAIT:
                 case T_ENUM:
-                    $inClassLevel = $level + 1;
+                    if (!$this->isKeywordUsedAsConstantName()) {
+                        $inClassLevel = $level + 1;
+                    }
+
                     break;
 
                 case T_USE:
@@ -109,10 +112,12 @@ class UsedSymbolExtractor
                     break;
 
                 case T_NAMESPACE:
-                    // namespace change
-                    $inGlobalScope = false;
-                    $useStatements = [];
-                    $useStatementKinds = [];
+                    if (!$this->isKeywordUsedAsConstantName()) {
+                        $inGlobalScope = false;
+                        $useStatements = [];
+                        $useStatementKinds = [];
+                    }
+
                     break;
 
                 case T_NAME_FULLY_QUALIFIED:
@@ -359,6 +364,18 @@ class UsedSymbolExtractor
         }
 
         return true;
+    }
+
+    /**
+     * Checks if the current keyword token is used as a constant name.
+     * E.g., SomeClass::NAMESPACE (access) or public const INTERFACE = 'value' (definition)
+     */
+    private function isKeywordUsedAsConstantName(): bool
+    {
+        $tokenBefore = $this->getTokenBefore($this->pointer - 2);
+
+        return $tokenBefore->id === T_DOUBLE_COLON
+            || $tokenBefore->id === T_CONST;
     }
 
     private function getTokenBefore(int $pointer): PhpToken

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -213,6 +213,30 @@ class UsedSymbolExtractorTest extends TestCase
             ],
         ];
 
+        // https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/256
+        yield 'namespace keyword as constant' => [
+            __DIR__ . '/data/not-autoloaded/used-symbols/namespace-keyword-constant.php',
+            [
+                SymbolKind::CLASSLIKE => [
+                    // Line 15: after "public const NAMESPACE = ..." (T_CONST case)
+                    // Line 27: after "ConstClass::NAMESPACE" (T_DOUBLE_COLON case)
+                    'Carbon\Carbon' => [15, 27],
+                ],
+            ],
+        ];
+
+        // Related to #256: CLASS/INTERFACE/TRAIT/ENUM keywords can also be constant names
+        yield 'class keyword as constant' => [
+            __DIR__ . '/data/not-autoloaded/used-symbols/class-keyword-constant.php',
+            [
+                SymbolKind::CLASSLIKE => [
+                    // Line 16: after "public const TRAIT = ..." (T_CONST case)
+                    // Line 37: after "Other::CLASS" and closure (T_DOUBLE_COLON case)
+                    'Carbon\Carbon' => [16, 37],
+                ],
+            ],
+        ];
+
         if (PHP_VERSION_ID >= 80_400) {
             yield 'property hooks' => [
                 __DIR__ . '/data/not-autoloaded/used-symbols/property-hooks.php',

--- a/tests/data/not-autoloaded/used-symbols/class-keyword-constant.php
+++ b/tests/data/not-autoloaded/used-symbols/class-keyword-constant.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App;
+
+use Carbon\Carbon;
+
+class ConstHolder
+{
+    // T_TRAIT after T_CONST - should not corrupt $inClassLevel
+    // (CLASS cannot be used as constant name - it's reserved for ::class)
+    public const TRAIT = 'some-trait';
+
+    public function test(): void
+    {
+        // Carbon should be detected here (after const TRAIT definition)
+        Carbon::now();
+    }
+}
+
+class Foo
+{
+    public function method(): void
+    {
+        // T_CLASS after T_DOUBLE_COLON - should not corrupt $inClassLevel
+        $x = Other::CLASS;
+
+        $fn = function () {
+            // closure that could cause spurious $inClassLevel reset
+        };
+    }
+
+    use App\SomeTrait; // trait use, NOT an import - should be ignored
+
+    public function bar(): void
+    {
+        // Carbon should be detected here (after ::CLASS and closure)
+        Carbon::now();
+    }
+}
+
+// SomeTrait should NOT be in use statements (trait use is not import)
+new SomeTrait();

--- a/tests/data/not-autoloaded/used-symbols/namespace-keyword-constant.php
+++ b/tests/data/not-autoloaded/used-symbols/namespace-keyword-constant.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App;
+
+use Carbon\Carbon;
+
+class ConstClass
+{
+    // T_NAMESPACE after T_CONST - should not reset use statements
+    public const NAMESPACE = 'some-namespace';
+
+    public function test(): void
+    {
+        // Carbon should be detected here (after const NAMESPACE definition)
+        Carbon::now();
+    }
+}
+
+class IssueHere
+{
+    public function init(): void
+    {
+        // T_NAMESPACE after T_DOUBLE_COLON - should not reset use statements
+        $namespace = ConstClass::NAMESPACE;
+
+        // Carbon should still be detected here (after ::NAMESPACE access)
+        Carbon::now();
+    }
+}


### PR DESCRIPTION
PHP reserved keywords (NAMESPACE, CLASS, INTERFACE, TRAIT, ENUM) can be used as class constant names. When accessed (e.g., Foo::NAMESPACE) or defined (e.g., const NAMESPACE = 'value'), PHP still tokenizes them as their keyword type (T_NAMESPACE, T_CLASS, etc.).

This caused the parser to incorrectly:
- Reset use statements when encountering T_NAMESPACE as a constant
- Corrupt $inClassLevel tracking when encountering T_CLASS/etc.

The fix checks if the keyword is preceded by T_DOUBLE_COLON or T_CONST before applying the keyword-specific handling.

Resolves #256 