### PR TITLE
Remove 14 failing E2E repos with broken composer installs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,21 +12,6 @@ jobs:
                     -
                         repo: TomasVotruba/unused-public
                     -
-                        repo: VasekPurchart/Console-Errors-Bundle
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: VasekPurchart/Phing-Copy-Files-Task
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: VasekPurchart/Phing-Symfony-Command-Task
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: VasekPurchart/Rabbit-Mq-Consumer-Handler-Bundle
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: VasekPurchart/Tracy-Blue-Screen-Bundle
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
                         repo: VincentLanglet/Twig-CS-Fixer
                     -
                         repo: alex-kalanis/kw_files
@@ -38,27 +23,6 @@ jobs:
                         repo: cdn77/PhpFunctions
                     -
                         repo: cdn77/RabbitMQBundle
-                    -
-                        repo: consistence/consistence
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: consistence/consistence-doctrine
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: consistence/consistence-doctrine-symfony
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: consistence/consistence-jms-serializer
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: consistence/consistence-jms-serializer-symfony
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: consistence/consistence-robot-loader-class-finder
-                        cdaArgs: --config=build/composer-dependency-analyser.config.php
-                    -
-                        repo: contao/contao
-                        cdaArgs: --disable-ext-analysis --config=depcheck.php
                     -
                         repo: idleberg/php-vite-manifest
                         cdaArgs: --disable-ext-analysis
@@ -74,8 +38,6 @@ jobs:
                     -
                         repo: inspirum/xml-php
                         cdaArgs: --disable-ext-analysis
-                    -
-                        repo: kreait/firebase-php
                     -
                         repo: mimmi20/ios-build
                     -
@@ -151,8 +113,6 @@ jobs:
                         repo: rectorphp/swiss-knife
                     -
                         repo: sensiolabs/GotenbergBundle
-                    -
-                        repo: shapecode/cron-bundle
                     -
                         repo: shipmonk-rnd/dead-code-detector
                     -

--- a/scripts/refresh-e2e.php
+++ b/scripts/refresh-e2e.php
@@ -93,10 +93,6 @@ foreach ($result as $index => &$item) {
         $item['composerArgs'] = '--no-plugins';
     }
 
-    if (strpos($item['repo'], 'consistence') === 0 || strpos($item['repo'], 'VasekPurchart') === 0) {
-        $item['cdaArgs'] = '--config=build/composer-dependency-analyser.config.php';
-    }
-
     if (
         strpos($item['repo'], 'oveleon') === 0
         || strpos($item['repo'], 'contao') === 0
@@ -123,6 +119,11 @@ foreach ($result as $index => &$item) {
         || $item['repo'] === 'oveleon/contao-cookiebar'
         || $item['repo'] === 'oveleon/contao-glossary-bundle'
         || $item['repo'] === 'oveleon/contao-theme-compiler-bundle'
+        || strpos($item['repo'], 'consistence/') === 0
+        || strpos($item['repo'], 'VasekPurchart/') === 0
+        || $item['repo'] === 'contao/contao'
+        || $item['repo'] === 'kreait/firebase-php'
+        || $item['repo'] === 'shapecode/cron-bundle'
     ) {
         unset($result[$index]); // failing builds
     }
@@ -133,7 +134,6 @@ foreach ($result as $index => &$item) {
         || $item['repo'] === 'inspirum/xml-php'
         || $item['repo'] === 'inspirum/balikobot-php'
         || $item['repo'] === 'idleberg/php-vite-manifest'
-        || $item['repo'] === 'contao/contao'
         || $item['repo'] === 'phpstan/phpstan-src'
         || $item['repo'] === 'mimmi20/monolog-factory'
     ) {


### PR DESCRIPTION
## Summary
- Remove 14 E2E matrix entries that fail at `composer install` on PHP 8.3: all `VasekPurchart/*`, all `consistence/*`, `contao/contao`, `kreait/firebase-php`, and `shapecode/cron-bundle`
- Add those repos to the exclusion list in `scripts/refresh-e2e.php` so they don't re-appear when the script is re-run
- Clean up dead code: remove `cdaArgs` assignment for consistence/VasekPurchart (excluded before it runs) and `contao/contao` from `--disable-ext-analysis` block

## Test plan
- [x] E2E workflow should pass with only the remaining (previously green) repos
- [ ] Run `php scripts/refresh-e2e.php` and verify none of the removed repos appear in the output

Co-Authored-By: Claude Code