### PR TITLE
Enhancement: Implement `JsonFormatter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This tool reads your `composer.json` and scans all paths listed in `autoload` & 
 - `--help` display usage & cli options
 - `--verbose` to see more example classes & usages
 - `--show-all-usages` to see all usages
-- `--format` to use different output format, available are: `console` (default), `junit`
+- `--format` to use different output format, available are: `console` (default), `json`, `junit`
 - `--disable-ext-analysis` to disable php extensions analysis (e.g. `ext-xml`)
 - `--ignore-unknown-classes` to globally ignore unknown classes
 - `--ignore-unknown-functions` to globally ignore unknown functions

--- a/src/Initializer.php
+++ b/src/Initializer.php
@@ -12,6 +12,7 @@ use ShipMonk\ComposerDependencyAnalyser\Exception\InvalidCliException;
 use ShipMonk\ComposerDependencyAnalyser\Exception\InvalidConfigException;
 use ShipMonk\ComposerDependencyAnalyser\Exception\InvalidPathException;
 use ShipMonk\ComposerDependencyAnalyser\Result\ConsoleFormatter;
+use ShipMonk\ComposerDependencyAnalyser\Result\JsonFormatter;
 use ShipMonk\ComposerDependencyAnalyser\Result\JunitFormatter;
 use ShipMonk\ComposerDependencyAnalyser\Result\ResultFormatter;
 use Throwable;
@@ -37,7 +38,7 @@ Options:
     --composer-json <path>      Provide custom path to composer.json
     --config <path>             Provide path to php configuration file
                                 (must return \ShipMonk\ComposerDependencyAnalyser\Config\Configuration instance)
-    --format <format>           Change output format. Available values: console (default), junit
+    --format <format>           Change output format. Available values: console (default), json, junit
 
 Ignore options:
     (or use --config for better granularity)
@@ -242,6 +243,14 @@ EOD;
     {
         $format = $options->format ?? 'console';
 
+        if ($format === 'json') {
+            if ($options->dumpUsages !== null) {
+                throw new InvalidConfigException("Cannot use 'json' format with '--dump-usages' option.");
+            }
+
+            return new JsonFormatter($this->cwd, $this->stdOutPrinter);
+        }
+
         if ($format === 'junit') {
             if ($options->dumpUsages !== null) {
                 throw new InvalidConfigException("Cannot use 'junit' format with '--dump-usages' option.");
@@ -254,7 +263,7 @@ EOD;
             return new ConsoleFormatter($this->cwd, $this->stdOutPrinter);
         }
 
-        throw new InvalidConfigException("Invalid format option provided, allowed are 'console' or 'junit'.");
+        throw new InvalidConfigException("Invalid format option provided, allowed are 'console', 'json' or 'junit'.");
     }
 
     private function deduceVersion(): string

--- a/src/Result/JsonFormatter.php
+++ b/src/Result/JsonFormatter.php
@@ -1,0 +1,249 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\ComposerDependencyAnalyser\Result;
+
+use ShipMonk\ComposerDependencyAnalyser\CliOptions;
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\Ignore\UnusedErrorIgnore;
+use ShipMonk\ComposerDependencyAnalyser\Config\Ignore\UnusedSymbolIgnore;
+use ShipMonk\ComposerDependencyAnalyser\Printer;
+use ShipMonk\ComposerDependencyAnalyser\SymbolKind;
+use function array_map;
+use function array_slice;
+use function json_encode;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+use const PHP_INT_MAX;
+
+class JsonFormatter implements ResultFormatter
+{
+
+    public function __construct(
+        private string $cwd,
+        private Printer $printer,
+    )
+    {
+    }
+
+    public function format(
+        AnalysisResult $result,
+        CliOptions $options,
+        Configuration $configuration,
+    ): int
+    {
+        $hasError = false;
+
+        $unknownClassErrors = $result->getUnknownClassErrors();
+        $unknownFunctionErrors = $result->getUnknownFunctionErrors();
+        $shadowDependencyErrors = $result->getShadowDependencyErrors();
+        $devDependencyInProductionErrors = $result->getDevDependencyInProductionErrors();
+        $prodDependencyOnlyInDevErrors = $result->getProdDependencyOnlyInDevErrors();
+        $unusedDependencyErrors = $result->getUnusedDependencyErrors();
+        $unusedIgnores = $result->getUnusedIgnores();
+
+        if (
+            $unknownClassErrors !== []
+            || $unknownFunctionErrors !== []
+            || $shadowDependencyErrors !== []
+            || $devDependencyInProductionErrors !== []
+            || $prodDependencyOnlyInDevErrors !== []
+            || $unusedDependencyErrors !== []
+        ) {
+            $hasError = true;
+        }
+
+        if ($unusedIgnores !== [] && $configuration->shouldReportUnmatchedIgnoredErrors()) {
+            $hasError = true;
+        }
+
+        $usagesLimit = $this->getMaxUsagesShownForErrors($options);
+
+        $data = [
+            'scannedFilesCount' => $result->getScannedFilesCount(),
+            'elapsedTime' => $result->getElapsedTime(),
+            'usagesPerSymbolLimit' => $usagesLimit === PHP_INT_MAX ? null : $usagesLimit,
+            'unknownSymbols' => [
+                'classes' => $this->serializeSymbolErrors($unknownClassErrors, $usagesLimit),
+                'functions' => $this->serializeSymbolErrors($unknownFunctionErrors, $usagesLimit),
+            ],
+            'shadowDependencies' => [
+                'packages' => $this->serializePackageErrors($shadowDependencyErrors, $usagesLimit),
+            ],
+            'devDependenciesInProd' => [
+                'packages' => $this->serializePackageErrors($devDependencyInProductionErrors, $usagesLimit),
+            ],
+            'prodDependenciesOnlyInDev' => [
+                'packages' => $this->serializePackageList($prodDependencyOnlyInDevErrors),
+            ],
+            'unusedDependencies' => [
+                'packages' => $this->serializePackageList($unusedDependencyErrors),
+            ],
+            'unusedIgnores' => $this->serializeUnusedIgnores($unusedIgnores),
+        ];
+
+        $json = json_encode(
+            $data,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+        );
+
+        $this->printer->print($json . "\n");
+
+        if ($hasError) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private function getMaxUsagesShownForErrors(CliOptions $options): int
+    {
+        if ($options->showAllUsages === true) {
+            return PHP_INT_MAX;
+        }
+
+        if ($options->verbose === true) {
+            return self::VERBOSE_SHOWN_USAGES;
+        }
+
+        return 1;
+    }
+
+    /**
+     * @param array<string, list<SymbolUsage>> $errors
+     * @return list<array{name: string, usages: list<array{file: string, line: int}>}>
+     */
+    private function serializeSymbolErrors(
+        array $errors,
+        int $usagesLimit,
+    ): array
+    {
+        $result = [];
+
+        foreach ($errors as $symbol => $usages) {
+            $result[] = [
+                'name' => $symbol,
+                'usages' => $this->serializeUsages($usages, $usagesLimit),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, array<string, list<SymbolUsage>>> $errors
+     * @return list<array{name: string, classes: list<array{name: string, usages: list<array{file: string, line: int}>}>, functions: list<array{name: string, usages: list<array{file: string, line: int}>}>}>
+     */
+    private function serializePackageErrors(
+        array $errors,
+        int $usagesLimit,
+    ): array
+    {
+        $result = [];
+
+        foreach ($errors as $package => $usagesPerSymbol) {
+            $classes = [];
+            $functions = [];
+
+            foreach ($usagesPerSymbol as $symbol => $usages) {
+                $serializedSymbol = [
+                    'name' => $symbol,
+                    'usages' => $this->serializeUsages($usages, $usagesLimit),
+                ];
+
+                $firstUsage = $usages[0] ?? null;
+
+                if ($firstUsage !== null && $firstUsage->getKind() === SymbolKind::FUNCTION) {
+                    $functions[] = $serializedSymbol;
+                } else {
+                    $classes[] = $serializedSymbol;
+                }
+            }
+
+            $result[] = [
+                'name' => $package,
+                'classes' => $classes,
+                'functions' => $functions,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<string> $packages
+     * @return list<array{name: string}>
+     */
+    private function serializePackageList(array $packages): array
+    {
+        return array_map(static function (string $name): array {
+            return ['name' => $name];
+        }, $packages);
+    }
+
+    /**
+     * @param list<SymbolUsage> $usages
+     * @return list<array{file: string, line: int}>
+     */
+    private function serializeUsages(
+        array $usages,
+        int $usagesLimit,
+    ): array
+    {
+        return array_map(function (SymbolUsage $usage): array {
+            return [
+                'file' => $this->relativizePath($usage->getFilepath()),
+                'line' => $usage->getLineNumber(),
+            ];
+        }, array_slice($usages, 0, $usagesLimit));
+    }
+
+    /**
+     * @param list<UnusedSymbolIgnore|UnusedErrorIgnore> $unusedIgnores
+     * @return array{symbols: list<array{kind: string, name: string, regex: bool}>, errors: list<array{errorType: string, package: string|null, path: string|null}>}
+     */
+    private function serializeUnusedIgnores(array $unusedIgnores): array
+    {
+        $symbols = [];
+        $errors = [];
+
+        foreach ($unusedIgnores as $ignore) {
+            if ($ignore instanceof UnusedSymbolIgnore) {
+                $symbols[] = [
+                    'kind' => $ignore->getSymbolKind() === SymbolKind::CLASSLIKE ? 'class' : 'function',
+                    'name' => $ignore->getUnknownSymbol(),
+                    'regex' => $ignore->isRegex(),
+                ];
+
+                continue;
+            }
+
+            $path = $ignore->getPath();
+
+            $errors[] = [
+                'errorType' => $ignore->getErrorType(),
+                'package' => $ignore->getPackage(),
+                'path' => $path === null ? null : $this->relativizePath($path),
+            ];
+        }
+
+        return [
+            'symbols' => $symbols,
+            'errors' => $errors,
+        ];
+    }
+
+    private function relativizePath(string $path): string
+    {
+        if (str_starts_with($path, $this->cwd)) {
+            return substr($path, strlen($this->cwd) + 1);
+        }
+
+        return $path;
+    }
+
+}

--- a/src/Result/SymbolUsage.php
+++ b/src/Result/SymbolUsage.php
@@ -31,7 +31,7 @@ class SymbolUsage
     /**
      * @return SymbolKind::*
      */
-    public function getKind(): int // @phpstan-ignore shipmonk.deadMethod
+    public function getKind(): int
     {
         return $this->kind;
     }

--- a/tests/InitializerTest.php
+++ b/tests/InitializerTest.php
@@ -9,6 +9,7 @@ use ShipMonk\ComposerDependencyAnalyser\Config\PathToScan;
 use ShipMonk\ComposerDependencyAnalyser\Exception\AbortException;
 use ShipMonk\ComposerDependencyAnalyser\Exception\InvalidConfigException;
 use ShipMonk\ComposerDependencyAnalyser\Result\ConsoleFormatter;
+use ShipMonk\ComposerDependencyAnalyser\Result\JsonFormatter;
 use ShipMonk\ComposerDependencyAnalyser\Result\JunitFormatter;
 use function count;
 use function dirname;
@@ -158,6 +159,10 @@ class InitializerTest extends TestCase
         $optionsFormatConsole->format = 'console';
         self::assertInstanceOf(ConsoleFormatter::class, $initializer->initFormatter($optionsFormatConsole));
 
+        $optionsFormatJson = new CliOptions();
+        $optionsFormatJson->format = 'json';
+        self::assertInstanceOf(JsonFormatter::class, $initializer->initFormatter($optionsFormatJson));
+
         $optionsFormatJunit = new CliOptions();
         $optionsFormatJunit->format = 'junit';
         self::assertInstanceOf(JunitFormatter::class, $initializer->initFormatter($optionsFormatJunit));
@@ -183,12 +188,21 @@ class InitializerTest extends TestCase
      */
     public static function provideInitFormatterFailures(): iterable
     {
+        $jsonWithDumpUsages = new CliOptions();
+        $jsonWithDumpUsages->format = 'json';
+        $jsonWithDumpUsages->dumpUsages = 'symfony/*';
+
         $junitWithDumpUsages = new CliOptions();
         $junitWithDumpUsages->format = 'junit';
         $junitWithDumpUsages->dumpUsages = 'symfony/*';
 
         $unknownFormat = new CliOptions();
         $unknownFormat->format = 'unknown';
+
+        yield 'json with dump-usages' => [
+            $jsonWithDumpUsages,
+            "Cannot use 'json' format with '--dump-usages' option.",
+        ];
 
         yield 'junit with dump-usages' => [
             $junitWithDumpUsages,
@@ -197,7 +211,7 @@ class InitializerTest extends TestCase
 
         yield 'unknown format' => [
             $unknownFormat,
-            "Invalid format option provided, allowed are 'console' or 'junit'.",
+            "Invalid format option provided, allowed are 'console', 'json' or 'junit'.",
         ];
     }
 

--- a/tests/JsonFormatterTest.php
+++ b/tests/JsonFormatterTest.php
@@ -1,0 +1,660 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\ComposerDependencyAnalyser;
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+use ShipMonk\ComposerDependencyAnalyser\Config\Ignore\UnusedErrorIgnore;
+use ShipMonk\ComposerDependencyAnalyser\Config\Ignore\UnusedSymbolIgnore;
+use ShipMonk\ComposerDependencyAnalyser\Result\AnalysisResult;
+use ShipMonk\ComposerDependencyAnalyser\Result\JsonFormatter;
+use ShipMonk\ComposerDependencyAnalyser\Result\ResultFormatter;
+use ShipMonk\ComposerDependencyAnalyser\Result\SymbolUsage;
+
+class JsonFormatterTest extends FormatterTestCase
+{
+
+    public function testPrintResult(): void
+    {
+        $noIssuesOutput = $this->getFormatterNormalizedOutput(static function (ResultFormatter $formatter): void {
+            $formatter->format(new AnalysisResult(2, 0.123, [], [], [], [], [], [], [], []), new CliOptions(), new Configuration());
+        });
+
+        $expectedNoIssuesOutput = <<<'OUT'
+{
+    "scannedFilesCount": 2,
+    "elapsedTime": 0.123,
+    "usagesPerSymbolLimit": 1,
+    "unknownSymbols": {
+        "classes": [],
+        "functions": []
+    },
+    "shadowDependencies": {
+        "packages": []
+    },
+    "devDependenciesInProd": {
+        "packages": []
+    },
+    "prodDependenciesOnlyInDev": {
+        "packages": []
+    },
+    "unusedDependencies": {
+        "packages": []
+    },
+    "unusedIgnores": {
+        "symbols": [],
+        "errors": []
+    }
+}
+
+OUT;
+
+        self::assertJsonStringEqualsJsonString($this->normalizeEol($expectedNoIssuesOutput), $noIssuesOutput);
+
+        $analysisResult = new AnalysisResult(
+            10,
+            0.123,
+            [],
+            ['Unknown\\Thing' => [
+                new SymbolUsage('/app/app/init.php', 1091, SymbolKind::CLASSLIKE),
+                new SymbolUsage('/app/app/init.php', 1093, SymbolKind::CLASSLIKE),
+            ]],
+            ['unknown_fn' => [new SymbolUsage('/app/app/foo.php', 51, SymbolKind::FUNCTION)]],
+            [
+                'shadow/package' => [
+                    'Shadow\\Utils' => [
+                        new SymbolUsage('/app/src/Utils.php', 19, SymbolKind::CLASSLIKE),
+                        new SymbolUsage('/app/src/Utils.php', 22, SymbolKind::CLASSLIKE),
+                        new SymbolUsage('/app/src/Application.php', 128, SymbolKind::CLASSLIKE),
+                        new SymbolUsage('/app/src/Controller.php', 229, SymbolKind::CLASSLIKE),
+                    ],
+                    'Shadow\\Comparator' => [new SymbolUsage('/app/src/Printer.php', 25, SymbolKind::CLASSLIKE)],
+                    'Third\\Parser' => [new SymbolUsage('/app/src/bootstrap.php', 317, SymbolKind::CLASSLIKE)],
+                    'Forth\\Provider' => [new SymbolUsage('/app/src/bootstrap.php', 873, SymbolKind::CLASSLIKE)],
+                    'shadow_helper' => [new SymbolUsage('/app/src/helpers.php', 12, SymbolKind::FUNCTION)],
+                ],
+                'shadow/another' => [
+                    'Another\\Controller' => [new SymbolUsage('/outside/bootstrap.php', 173, SymbolKind::CLASSLIKE)],
+                ],
+            ],
+            ['some/package' => ['Another\\Command' => [new SymbolUsage('/app/src/ProductGenerator.php', 28, SymbolKind::CLASSLIKE)]]],
+            ['misplaced/package'],
+            ['dead/package'],
+            [],
+        );
+
+        $regularOutput = $this->getFormatterNormalizedOutput(static function ($formatter) use ($analysisResult): void {
+            $formatter->format($analysisResult, new CliOptions(), new Configuration());
+        });
+
+        $expectedRegularOutput = <<<'OUT'
+{
+    "scannedFilesCount": 10,
+    "elapsedTime": 0.123,
+    "usagesPerSymbolLimit": 1,
+    "unknownSymbols": {
+        "classes": [
+            {
+                "name": "Unknown\\Thing",
+                "usages": [
+                    {
+                        "file": "app/init.php",
+                        "line": 1091
+                    }
+                ]
+            }
+        ],
+        "functions": [
+            {
+                "name": "unknown_fn",
+                "usages": [
+                    {
+                        "file": "app/foo.php",
+                        "line": 51
+                    }
+                ]
+            }
+        ]
+    },
+    "shadowDependencies": {
+        "packages": [
+            {
+                "name": "shadow/another",
+                "classes": [
+                    {
+                        "name": "Another\\Controller",
+                        "usages": [
+                            {
+                                "file": "/outside/bootstrap.php",
+                                "line": 173
+                            }
+                        ]
+                    }
+                ],
+                "functions": []
+            },
+            {
+                "name": "shadow/package",
+                "classes": [
+                    {
+                        "name": "Forth\\Provider",
+                        "usages": [
+                            {
+                                "file": "src/bootstrap.php",
+                                "line": 873
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Shadow\\Comparator",
+                        "usages": [
+                            {
+                                "file": "src/Printer.php",
+                                "line": 25
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Shadow\\Utils",
+                        "usages": [
+                            {
+                                "file": "src/Utils.php",
+                                "line": 19
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Third\\Parser",
+                        "usages": [
+                            {
+                                "file": "src/bootstrap.php",
+                                "line": 317
+                            }
+                        ]
+                    }
+                ],
+                "functions": [
+                    {
+                        "name": "shadow_helper",
+                        "usages": [
+                            {
+                                "file": "src/helpers.php",
+                                "line": 12
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "devDependenciesInProd": {
+        "packages": [
+            {
+                "name": "some/package",
+                "classes": [
+                    {
+                        "name": "Another\\Command",
+                        "usages": [
+                            {
+                                "file": "src/ProductGenerator.php",
+                                "line": 28
+                            }
+                        ]
+                    }
+                ],
+                "functions": []
+            }
+        ]
+    },
+    "prodDependenciesOnlyInDev": {
+        "packages": [
+            {
+                "name": "misplaced/package"
+            }
+        ]
+    },
+    "unusedDependencies": {
+        "packages": [
+            {
+                "name": "dead/package"
+            }
+        ]
+    },
+    "unusedIgnores": {
+        "symbols": [],
+        "errors": []
+    }
+}
+
+OUT;
+
+        self::assertJsonStringEqualsJsonString($this->normalizeEol($expectedRegularOutput), $regularOutput);
+
+        $verboseOptions = new CliOptions();
+        $verboseOptions->verbose = true;
+
+        $verboseOutput = $this->getFormatterNormalizedOutput(static function ($formatter) use ($analysisResult, $verboseOptions): void {
+            $formatter->format($analysisResult, $verboseOptions, new Configuration());
+        });
+
+        $expectedVerboseOutput = <<<'OUT'
+{
+    "scannedFilesCount": 10,
+    "elapsedTime": 0.123,
+    "usagesPerSymbolLimit": 3,
+    "unknownSymbols": {
+        "classes": [
+            {
+                "name": "Unknown\\Thing",
+                "usages": [
+                    {
+                        "file": "app/init.php",
+                        "line": 1091
+                    },
+                    {
+                        "file": "app/init.php",
+                        "line": 1093
+                    }
+                ]
+            }
+        ],
+        "functions": [
+            {
+                "name": "unknown_fn",
+                "usages": [
+                    {
+                        "file": "app/foo.php",
+                        "line": 51
+                    }
+                ]
+            }
+        ]
+    },
+    "shadowDependencies": {
+        "packages": [
+            {
+                "name": "shadow/another",
+                "classes": [
+                    {
+                        "name": "Another\\Controller",
+                        "usages": [
+                            {
+                                "file": "/outside/bootstrap.php",
+                                "line": 173
+                            }
+                        ]
+                    }
+                ],
+                "functions": []
+            },
+            {
+                "name": "shadow/package",
+                "classes": [
+                    {
+                        "name": "Forth\\Provider",
+                        "usages": [
+                            {
+                                "file": "src/bootstrap.php",
+                                "line": 873
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Shadow\\Comparator",
+                        "usages": [
+                            {
+                                "file": "src/Printer.php",
+                                "line": 25
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Shadow\\Utils",
+                        "usages": [
+                            {
+                                "file": "src/Utils.php",
+                                "line": 19
+                            },
+                            {
+                                "file": "src/Utils.php",
+                                "line": 22
+                            },
+                            {
+                                "file": "src/Application.php",
+                                "line": 128
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Third\\Parser",
+                        "usages": [
+                            {
+                                "file": "src/bootstrap.php",
+                                "line": 317
+                            }
+                        ]
+                    }
+                ],
+                "functions": [
+                    {
+                        "name": "shadow_helper",
+                        "usages": [
+                            {
+                                "file": "src/helpers.php",
+                                "line": 12
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "devDependenciesInProd": {
+        "packages": [
+            {
+                "name": "some/package",
+                "classes": [
+                    {
+                        "name": "Another\\Command",
+                        "usages": [
+                            {
+                                "file": "src/ProductGenerator.php",
+                                "line": 28
+                            }
+                        ]
+                    }
+                ],
+                "functions": []
+            }
+        ]
+    },
+    "prodDependenciesOnlyInDev": {
+        "packages": [
+            {
+                "name": "misplaced/package"
+            }
+        ]
+    },
+    "unusedDependencies": {
+        "packages": [
+            {
+                "name": "dead/package"
+            }
+        ]
+    },
+    "unusedIgnores": {
+        "symbols": [],
+        "errors": []
+    }
+}
+
+OUT;
+
+        self::assertJsonStringEqualsJsonString($this->normalizeEol($expectedVerboseOutput), $verboseOutput);
+
+        $showAllOptions = new CliOptions();
+        $showAllOptions->showAllUsages = true;
+
+        $showAllOutput = $this->getFormatterNormalizedOutput(static function ($formatter) use ($analysisResult, $showAllOptions): void {
+            $formatter->format($analysisResult, $showAllOptions, new Configuration());
+        });
+
+        $expectedShowAllOutput = <<<'OUT'
+{
+    "scannedFilesCount": 10,
+    "elapsedTime": 0.123,
+    "usagesPerSymbolLimit": null,
+    "unknownSymbols": {
+        "classes": [
+            {
+                "name": "Unknown\\Thing",
+                "usages": [
+                    {
+                        "file": "app/init.php",
+                        "line": 1091
+                    },
+                    {
+                        "file": "app/init.php",
+                        "line": 1093
+                    }
+                ]
+            }
+        ],
+        "functions": [
+            {
+                "name": "unknown_fn",
+                "usages": [
+                    {
+                        "file": "app/foo.php",
+                        "line": 51
+                    }
+                ]
+            }
+        ]
+    },
+    "shadowDependencies": {
+        "packages": [
+            {
+                "name": "shadow/another",
+                "classes": [
+                    {
+                        "name": "Another\\Controller",
+                        "usages": [
+                            {
+                                "file": "/outside/bootstrap.php",
+                                "line": 173
+                            }
+                        ]
+                    }
+                ],
+                "functions": []
+            },
+            {
+                "name": "shadow/package",
+                "classes": [
+                    {
+                        "name": "Forth\\Provider",
+                        "usages": [
+                            {
+                                "file": "src/bootstrap.php",
+                                "line": 873
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Shadow\\Comparator",
+                        "usages": [
+                            {
+                                "file": "src/Printer.php",
+                                "line": 25
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Shadow\\Utils",
+                        "usages": [
+                            {
+                                "file": "src/Utils.php",
+                                "line": 19
+                            },
+                            {
+                                "file": "src/Utils.php",
+                                "line": 22
+                            },
+                            {
+                                "file": "src/Application.php",
+                                "line": 128
+                            },
+                            {
+                                "file": "src/Controller.php",
+                                "line": 229
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Third\\Parser",
+                        "usages": [
+                            {
+                                "file": "src/bootstrap.php",
+                                "line": 317
+                            }
+                        ]
+                    }
+                ],
+                "functions": [
+                    {
+                        "name": "shadow_helper",
+                        "usages": [
+                            {
+                                "file": "src/helpers.php",
+                                "line": 12
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "devDependenciesInProd": {
+        "packages": [
+            {
+                "name": "some/package",
+                "classes": [
+                    {
+                        "name": "Another\\Command",
+                        "usages": [
+                            {
+                                "file": "src/ProductGenerator.php",
+                                "line": 28
+                            }
+                        ]
+                    }
+                ],
+                "functions": []
+            }
+        ]
+    },
+    "prodDependenciesOnlyInDev": {
+        "packages": [
+            {
+                "name": "misplaced/package"
+            }
+        ]
+    },
+    "unusedDependencies": {
+        "packages": [
+            {
+                "name": "dead/package"
+            }
+        ]
+    },
+    "unusedIgnores": {
+        "symbols": [],
+        "errors": []
+    }
+}
+
+OUT;
+
+        self::assertJsonStringEqualsJsonString($this->normalizeEol($expectedShowAllOutput), $showAllOutput);
+
+        $unusedIgnoresResult = new AnalysisResult(
+            2,
+            0.5,
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [
+                new UnusedSymbolIgnore('Foo\\Bar', false, SymbolKind::CLASSLIKE),
+                new UnusedSymbolIgnore('~^Legacy\\\\~', true, SymbolKind::CLASSLIKE),
+                new UnusedSymbolIgnore('legacy_helper', false, SymbolKind::FUNCTION),
+                new UnusedErrorIgnore(ErrorType::SHADOW_DEPENDENCY, null, null),
+                new UnusedErrorIgnore(ErrorType::SHADOW_DEPENDENCY, null, 'nette/utils'),
+                new UnusedErrorIgnore(ErrorType::SHADOW_DEPENDENCY, '/app/src/X.php', null),
+                new UnusedErrorIgnore(ErrorType::SHADOW_DEPENDENCY, '/app/src/X.php', 'nette/utils'),
+            ],
+        );
+
+        $unusedIgnoresOutput = $this->getFormatterNormalizedOutput(static function ($formatter) use ($unusedIgnoresResult): void {
+            $formatter->format($unusedIgnoresResult, new CliOptions(), new Configuration());
+        });
+
+        $expectedUnusedIgnoresOutput = <<<'OUT'
+{
+    "scannedFilesCount": 2,
+    "elapsedTime": 0.5,
+    "usagesPerSymbolLimit": 1,
+    "unknownSymbols": {
+        "classes": [],
+        "functions": []
+    },
+    "shadowDependencies": {
+        "packages": []
+    },
+    "devDependenciesInProd": {
+        "packages": []
+    },
+    "prodDependenciesOnlyInDev": {
+        "packages": []
+    },
+    "unusedDependencies": {
+        "packages": []
+    },
+    "unusedIgnores": {
+        "symbols": [
+            {
+                "kind": "class",
+                "name": "Foo\\Bar",
+                "regex": false
+            },
+            {
+                "kind": "class",
+                "name": "~^Legacy\\\\~",
+                "regex": true
+            },
+            {
+                "kind": "function",
+                "name": "legacy_helper",
+                "regex": false
+            }
+        ],
+        "errors": [
+            {
+                "errorType": "shadow-dependency",
+                "package": null,
+                "path": null
+            },
+            {
+                "errorType": "shadow-dependency",
+                "package": "nette/utils",
+                "path": null
+            },
+            {
+                "errorType": "shadow-dependency",
+                "package": null,
+                "path": "src/X.php"
+            },
+            {
+                "errorType": "shadow-dependency",
+                "package": "nette/utils",
+                "path": "src/X.php"
+            }
+        ]
+    }
+}
+
+OUT;
+
+        self::assertJsonStringEqualsJsonString($this->normalizeEol($expectedUnusedIgnoresOutput), $unusedIgnoresOutput);
+    }
+
+    protected function createFormatter(Printer $printer): ResultFormatter
+    {
+        return new JsonFormatter('/app', $printer);
+    }
+
+}


### PR DESCRIPTION
This pull request

- [x] implements a `JsonFormatter`

💁‍♂️ This could be useful for AI agents - for example, `composer-dependency-analyser` could automatically switch to using the `json` format in the presence of an AI agent, detected via

- [`shipfastlabs/agent-detector`](https://github.com/shipfastlabs/agent-detector)
- [`ergebnis/agent-detector`](https://github.com/ergebnis/agent-detector), inspired by the former
- inlining any of the above, or suggesting to set and inspect a generic `AI_AGENT` environment variable