### PR TITLE
Fix classlike symbols matching extension function names

### DIFF
--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -161,7 +161,13 @@ class UsedSymbolExtractor
 
                     } elseif (isset($knownSymbols[$lowerName])) {
                         $symbolName = $name;
-                        $kind = $knownSymbols[$lowerName];
+                        $knownKind = $knownSymbols[$lowerName];
+
+                        // FUNCTION/CLASSLIKE names can collide (e.g. a class named like an extension function),
+                        // so prefer syntactic context over the known kind; CONSTANT cannot be inferred from context.
+                        $kind = $knownKind === SymbolKind::CONSTANT
+                            ? SymbolKind::CONSTANT
+                            : $this->getFqnSymbolKind($pointerBeforeName, $pointerAfterName, $inAttributeSquareLevel !== null);
 
                         if (!$inGlobalScope && $kind === SymbolKind::CLASSLIKE) {
                             break; // cannot use class-like symbols in non-global scope when not imported

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -237,6 +237,22 @@ class UsedSymbolExtractorTest extends TestCase
             ],
         ];
 
+        // https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/264
+        yield 'symbol kind collision' => [
+            __DIR__ . '/data/not-autoloaded/used-symbols/symbol-kind-collision.php',
+            [
+                SymbolKind::CLASSLIKE => [
+                    'pcntl_fork' => [4, 5],
+                ],
+                SymbolKind::FUNCTION => [
+                    'pcntl_fork' => [8],
+                ],
+            ],
+            [
+                strtolower('pcntl_fork') => SymbolKind::FUNCTION,
+            ],
+        ];
+
         if (PHP_VERSION_ID >= 80_400) {
             yield 'property hooks' => [
                 __DIR__ . '/data/not-autoloaded/used-symbols/property-hooks.php',

--- a/tests/data/not-autoloaded/used-symbols/symbol-kind-collision.php
+++ b/tests/data/not-autoloaded/used-symbols/symbol-kind-collision.php
@@ -1,0 +1,9 @@
+<?php
+
+class pcntl_fork {}
+function testTypeHint(pcntl_fork $arg): void {}
+testTypeHint(new pcntl_fork());
+
+function testFunctionCall(): void {
+    pcntl_fork();
+}


### PR DESCRIPTION
## Summary

- In the `T_STRING` branch of `UsedSymbolExtractor::parseUsedSymbols`, symbol kind was taken verbatim from known extension symbols. When a user declared a class whose name collided with an extension function (e.g. `class pcntl_fork {}`), its classlike uses (type hints, `new`) were mis-tagged as `FUNCTION`, producing a spurious shadow dependency warning for the extension.
- Use syntactic context via `getFqnSymbolKind()` to choose between `FUNCTION` and `CLASSLIKE` (same heuristic already applied to `T_NAME_FULLY_QUALIFIED` / `T_NAME_QUALIFIED`). `CONSTANT` stays trusted because context alone cannot distinguish a bare constant from a classlike reference.
- New regression test `symbol kind collision` covers the three contexts from the issue repro: type hint, `new`, and a real function call — all with `pcntl_fork` mapped as a known `FUNCTION`.

Fixes #264

## Test plan

- [x] `vendor/bin/phpunit` — 124 tests pass (1 skipped, phar environment)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/phpcs` — no errors
- [x] End-to-end repro from the issue no longer reports a shadow dependency for `ext-pcntl`

Co-Authored-By: Claude Code