### PR TITLE
Add support for clickable paths in CLI output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !/cache/.gitkeep
 /.idea
 /phpstan.neon
+/composer-dependency-analyser.local.php

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ return $config
     // - designed for DIC config files (see below)
     // - beware that those are not validated and do not even trigger unknown class error
     ->addForceUsedSymbols($classesExtractedFromNeonJsonYamlXmlEtc)
+
+    //// Make CLI file paths clickable to your IDE (uses OSC 8 hyperlinks)
+    // Available placeholders: {file}, {relFile}, {line}
+    ->setEditorUrl('phpstorm://open?file={file}&line={line}')
 ```
 
 All paths are expected to exist. If you need some glob functionality, you can do it in your config file and pass the expanded list to e.g. `ignoreErrorsOnPaths`.

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -3,7 +3,8 @@
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
-return (new Configuration())
+$config = new Configuration();
+$config
     ->addPathToScan(__FILE__, true)
     ->addPathToScan(__DIR__ . '/bin', false)
     ->addPathToExclude(__DIR__ . '/tests/data')
@@ -12,3 +13,10 @@ return (new Configuration())
         [__DIR__ . '/src/Result/JunitFormatter.php'], // optional usages guarded with extension_loaded()
         [ErrorType::DEV_DEPENDENCY_IN_PROD],
     );
+
+$localConfig = __DIR__ . '/composer-dependency-analyser.local.php';
+if (is_file($localConfig)) {
+    require $localConfig; // handy for $config->setEditorUrl()
+}
+
+return $config;

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -90,6 +90,8 @@ class Configuration
      */
     private array $ignoredUnknownFunctionsRegexes = [];
 
+    private ?string $editorUrl = null;
+
     /**
      * Disable analysis of ext-* dependencies
      *
@@ -578,6 +580,32 @@ class Configuration
 
         $this->ignoredUnknownFunctionsRegexes[] = $functionNameRegex;
         return $this;
+    }
+
+    /**
+     * Set the editor URL pattern to make filepaths clickable in CLI output via OSC 8 hyperlink.
+     *
+     * Available placeholders:
+     * - {file} - Absolute file path
+     * - {relFile} - Relative file path (from current working directory)
+     * - {line} - Line number
+     *
+     * Common editor URL patterns:
+     * - PHPStorm: phpstorm://open?file={file}&line={line}
+     * - VS Code: vscode://file/{file}:{line}
+     * - Sublime: subl://open?url=file://{file}&line={line}
+     *
+     * @return $this
+     */
+    public function setEditorUrl(string $editorUrl): self
+    {
+        $this->editorUrl = $editorUrl;
+        return $this;
+    }
+
+    public function getEditorUrl(): ?string
+    {
+        return $this->editorUrl;
     }
 
     public function getIgnoreList(): IgnoreList

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -47,6 +47,11 @@ class Printer
         }
     }
 
+    public function hasDisabledColors(): bool
+    {
+        return $this->noColor;
+    }
+
     private function colorize(string $string): string
     {
         return str_replace(

--- a/src/Result/ConsoleFormatter.php
+++ b/src/Result/ConsoleFormatter.php
@@ -14,6 +14,7 @@ use function count;
 use function fnmatch;
 use function in_array;
 use function round;
+use function str_replace;
 use function strlen;
 use function strpos;
 use function substr;
@@ -22,6 +23,8 @@ use const PHP_INT_MAX;
 
 class ConsoleFormatter implements ResultFormatter
 {
+
+    private ?string $editorUrl = null;
 
     public function __construct(
         private string $cwd,
@@ -36,6 +39,8 @@ class ConsoleFormatter implements ResultFormatter
         Configuration $configuration,
     ): int
     {
+        $this->editorUrl = $configuration->getEditorUrl();
+
         if ($options->dumpUsages !== null) {
             return $this->printResultUsages($result, $options->dumpUsages, $options->showAllUsages === true);
         }
@@ -344,7 +349,9 @@ class ConsoleFormatter implements ResultFormatter
 
     private function relativizeUsage(SymbolUsage $usage): string
     {
-        return "{$this->relativizePath($usage->getFilepath())}:{$usage->getLineNumber()}";
+        $filepath = $usage->getFilepath();
+        $line = $usage->getLineNumber();
+        return $this->makeClickable("{$this->relativizePath($filepath)}:{$line}", $filepath, $line);
     }
 
     private function relativizePath(string $path): string
@@ -354,6 +361,30 @@ class ConsoleFormatter implements ResultFormatter
         }
 
         return $path;
+    }
+
+    private function makeClickable(
+        string $text,
+        string $filepath,
+        int $line,
+    ): string
+    {
+        if ($this->editorUrl === null) {
+            return $text;
+        }
+
+        if ($this->printer->hasDisabledColors()) {
+            return $text;
+        }
+
+        $url = str_replace(
+            ['{relFile}', '{file}', '{line}'],
+            [$this->relativizePath($filepath), $filepath, (string) $line],
+            $this->editorUrl,
+        );
+
+        // OSC 8 hyperlink
+        return "\033]8;;{$url}\033\\{$text}\033]8;;\033\\";
     }
 
     /**

--- a/tests/ConsoleFormatterTest.php
+++ b/tests/ConsoleFormatterTest.php
@@ -9,6 +9,8 @@ use ShipMonk\ComposerDependencyAnalyser\Result\AnalysisResult;
 use ShipMonk\ComposerDependencyAnalyser\Result\ConsoleFormatter;
 use ShipMonk\ComposerDependencyAnalyser\Result\ResultFormatter;
 use ShipMonk\ComposerDependencyAnalyser\Result\SymbolUsage;
+use function fopen;
+use function stream_get_contents;
 
 class ConsoleFormatterTest extends FormatterTestCase
 {
@@ -245,6 +247,106 @@ Dumping sample usages of symfony/console
 OUT;
 
         self::assertSame($this->normalizeEol($expectedOutput), $output);
+    }
+
+    public function testPrintResultEmitsClickableHyperlinksWhenEditorUrlConfigured(): void
+    {
+        $analysisResult = new AnalysisResult(
+            10,
+            0.123,
+            [],
+            ['Unknown\\Thing' => [new SymbolUsage('/app/app/init.php', 1093, SymbolKind::CLASSLIKE)]],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        );
+
+        $stream = fopen('php://memory', 'w');
+        self::assertNotFalse($stream);
+
+        $coloredPrinter = new Printer($stream, false);
+        $formatter = new ConsoleFormatter('/app', $coloredPrinter);
+
+        $configuration = new Configuration();
+        $configuration->setEditorUrl('phpstorm://open?file={file}&line={line}');
+
+        $formatter->format($analysisResult, new CliOptions(), $configuration);
+
+        $output = (string) stream_get_contents($stream, -1, 0);
+
+        // OSC 8 hyperlink wrapper: ESC ] 8 ; ; URL ESC \ TEXT ESC ] 8 ; ; ESC \
+        self::assertStringContainsString("\033]8;;phpstorm://open?file=/app/app/init.php&line=1093\033\\app/init.php:1093\033]8;;\033\\", $output);
+    }
+
+    public function testPrintResultUsagesEmitsClickableHyperlinksWhenEditorUrlConfigured(): void
+    {
+        $analysisResult = new AnalysisResult(
+            scannedFilesCount: 5,
+            elapsedTime: 0.456,
+            usages: [
+                'symfony/console' => [
+                    'Symfony\Component\Console\Application' => [
+                        new SymbolUsage('/app/src/Application.php', 5, SymbolKind::CLASSLIKE),
+                    ],
+                    'Symfony\Component\Console\Command\Command' => [
+                        new SymbolUsage('/app/src/MyCommand.php', 10, SymbolKind::CLASSLIKE),
+                    ],
+                ],
+            ],
+            unknownClassErrors: [],
+            unknownFunctionErrors: [],
+            shadowDependencyErrors: [],
+            devDependencyInProductionErrors: [],
+            prodDependencyOnlyInDevErrors: [],
+            unusedDependencyErrors: [],
+            unusedIgnores: [],
+        );
+
+        $stream = fopen('php://memory', 'w');
+        self::assertNotFalse($stream);
+
+        $coloredPrinter = new Printer($stream, false);
+        $formatter = new ConsoleFormatter('/app', $coloredPrinter);
+
+        $configuration = new Configuration();
+        $configuration->setEditorUrl('phpstorm://open?file={file}&line={line}');
+
+        $options = new CliOptions();
+        $options->dumpUsages = 'symfony/console';
+        $formatter->format($analysisResult, $options, $configuration);
+
+        $output = (string) stream_get_contents($stream, -1, 0);
+
+        self::assertStringContainsString("\033]8;;phpstorm://open?file=/app/src/Application.php&line=5\033\\src/Application.php:5\033]8;;\033\\", $output);
+        self::assertStringContainsString("\033]8;;phpstorm://open?file=/app/src/MyCommand.php&line=10\033\\src/MyCommand.php:10\033]8;;\033\\", $output);
+    }
+
+    public function testPrintResultSkipsClickableHyperlinksWhenColorsDisabled(): void
+    {
+        $analysisResult = new AnalysisResult(
+            10,
+            0.123,
+            [],
+            ['Unknown\\Thing' => [new SymbolUsage('/app/app/init.php', 1093, SymbolKind::CLASSLIKE)]],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        );
+
+        $configuration = new Configuration();
+        $configuration->setEditorUrl('phpstorm://open?file={file}&line={line}');
+
+        $output = $this->getFormatterNormalizedOutput(static function (ResultFormatter $formatter) use ($analysisResult, $configuration): void {
+            $formatter->format($analysisResult, new CliOptions(), $configuration);
+        });
+
+        self::assertStringNotContainsString("\033]8;", $output);
     }
 
     protected function createFormatter(Printer $printer): ResultFormatter


### PR DESCRIPTION
## Summary
- Adds `Configuration::setEditorUrl()` to make `path:line` references in console output clickable via OSC 8 hyperlinks, mirroring the API in `shipmonk/coverage-guard` and `shipmonk/copy-paste-detector`.
- Available placeholders: `{file}`, `{relFile}`, `{line}`. Common patterns:
  - PHPStorm: `phpstorm://open?file={file}&line={line}`
  - VS Code: `vscode://file/{file}:{line}`
  - Sublime: `subl://open?url=file://{file}&line={line}`
- Hyperlinks are skipped when colors are disabled (`NO_COLOR`).
- Applies to all `path:line` outputs (errors, dump-usages, verbose mode).

## Test plan
- [x] `vendor/bin/phpunit` (incl. new tests in `tests/ConsoleFormatterTest.php`)
- [x] `vendor/bin/phpstan analyse`
- [x] `vendor/bin/phpcs`
- [x] Manual: `php bin/composer-dependency-analyser` with `setEditorUrl(...)` in config emits OSC 8 sequences around each `path:line`
- [x] Manual: `--dump-usages` output also clickable
- [x] Manual: `NO_COLOR=1` suppresses hyperlinks