### PR TITLE
Update phpstan to ^2.2 and fix violations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-libxml": "*",
         "editorconfig-checker/editorconfig-checker": "^10.7.0",
         "ergebnis/composer-normalize": "^2.19.0",
-        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5.62",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "605bd0671c5402586330f5ebc71a1fdf",
+    "content-hash": "23221c568e9effaab69fdc663cd78a7c",
     "packages": [],
     "packages-dev": [
         {
@@ -1261,11 +1261,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.46",
+            "version": "2.2.0",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
-                "reference": "a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4cd98348c809924f62bb9cc8c047f5e73bc9a58",
+                "reference": "b4cd98348c809924f62bb9cc8c047f5e73bc9a58",
                 "shasum": ""
             },
             "require": {
@@ -1287,6 +1287,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -1310,7 +1321,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-01T09:25:14+00:00"
+            "time": "2026-05-28T08:22:43+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/scripts/refresh-e2e.php
+++ b/scripts/refresh-e2e.php
@@ -48,7 +48,7 @@ function fetchRepository(string $packageName): string
 }
 
 /**
- * @param list<array{repo: string, cdaArgs?: string, composerArgs?: string}> $items
+ * @param list<array{repo: string, cdaArgs?: string, composerArgs?: string, php?: string}> $items
  */
 function outputYaml(array $items): void
 {

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -32,7 +32,7 @@ class CliTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{string|null, list<string>}>
+     * @return iterable<string, array{string|null, list<string>, 2?: CliOptions}>
      */
     public static function validationDataProvider(): iterable
     {


### PR DESCRIPTION
## Summary
- Bump `phpstan/phpstan` to `^2.2`
- Fix two sealed-array-shape violations surfaced by the upgrade:
  - `tests/CliTest.php` — data provider tuple now declares optional `CliOptions` element
  - `scripts/refresh-e2e.php` — `outputYaml` array shape now allows optional `php` key

## Test plan
- [x] `composer check:types`
- [x] `composer check:scripts`
- [x] `composer check`

Co-Authored-By: Claude Code