### PR TITLE
Adopt new shipmonk/coding-standard custom sniffs

### DIFF
--- a/bin/composer-dependency-analyser
+++ b/bin/composer-dependency-analyser
@@ -53,9 +53,9 @@ try {
     $exitCode = $formatter->format($result, $options, $configuration);
 
 } catch (
-    InvalidPathException |
+    InvalidCliException |
     InvalidConfigException |
-    InvalidCliException $e
+    InvalidPathException $e
 ) {
     $stdErrPrinter->printLine("\n<red>{$e->getMessage()}</red>" . PHP_EOL);
     exit(1);

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5.62",
-        "shipmonk/coding-standard": "^0.2.0",
+        "shipmonk/coding-standard": "dev-add-generic-custom-sniffs",
         "shipmonk/coverage-guard": "^1.0.0",
         "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "^2.1.1"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5.62",
-        "shipmonk/coding-standard": "dev-add-generic-custom-sniffs",
+        "shipmonk/coding-standard": "^0.3.0",
         "shipmonk/coverage-guard": "^1.0.0",
         "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "^2.1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -2813,12 +2813,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844"
+                "reference": "19a85333ebd6ed95316c4e525548ae5d03ed6a6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/556e3d2499dec123904ec09d90e5d1d8a2b36844",
-                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/19a85333ebd6ed95316c4e525548ae5d03ed6a6a",
+                "reference": "19a85333ebd6ed95316c4e525548ae5d03ed6a6a",
                 "shasum": ""
             },
             "require": {
@@ -2855,7 +2855,7 @@
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
                 "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
             },
-            "time": "2026-06-22T07:30:14+00:00"
+            "time": "2026-06-22T10:49:49+00:00"
         },
         {
             "name": "shipmonk/coverage-guard",

--- a/composer.lock
+++ b/composer.lock
@@ -2813,12 +2813,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "19a85333ebd6ed95316c4e525548ae5d03ed6a6a"
+                "reference": "0bc44b528497e379e30641edde64b9d425795a7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/19a85333ebd6ed95316c4e525548ae5d03ed6a6a",
-                "reference": "19a85333ebd6ed95316c4e525548ae5d03ed6a6a",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/0bc44b528497e379e30641edde64b9d425795a7a",
+                "reference": "0bc44b528497e379e30641edde64b9d425795a7a",
                 "shasum": ""
             },
             "require": {
@@ -2855,7 +2855,7 @@
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
                 "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
             },
-            "time": "2026-06-22T10:49:49+00:00"
+            "time": "2026-06-22T10:52:55+00:00"
         },
         {
             "name": "shipmonk/coverage-guard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3ce76ddb74ded15068d0dce5365288f",
+    "content-hash": "c2c6e0a2a324da149cc98bee84898e7c",
     "packages": [],
     "packages-dev": [
         {
@@ -2809,21 +2809,21 @@
         },
         {
             "name": "shipmonk/coding-standard",
-            "version": "dev-add-generic-custom-sniffs",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "0bc44b528497e379e30641edde64b9d425795a7a"
+                "reference": "15182bf6b0e17682990c049dd17f593d3235ec62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/0bc44b528497e379e30641edde64b9d425795a7a",
-                "reference": "0bc44b528497e379e30641edde64b9d425795a7a",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/15182bf6b0e17682990c049dd17f593d3235ec62",
+                "reference": "15182bf6b0e17682990c049dd17f593d3235ec62",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.4 || ^8.0",
+                "php": "^8.1",
                 "slevomat/coding-standard": "^8.28.0",
                 "squizlabs/php_codesniffer": "^4.0.1"
             },
@@ -2834,9 +2834,9 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
+                "phpunit/phpunit": "^10.5.62",
                 "shipmonk/composer-dependency-analyser": "^1.8",
-                "shipmonk/dead-code-detector": "^0.12",
+                "shipmonk/dead-code-detector": "^1.0",
                 "shipmonk/name-collision-detector": "^2.1",
                 "shipmonk/phpstan-rules": "^4.1"
             },
@@ -2853,9 +2853,9 @@
             "description": "PHP Coding Standard used in ShipMonk",
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
-                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
+                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.3.0"
             },
-            "time": "2026-06-22T10:52:55+00:00"
+            "time": "2026-06-23T07:41:40+00:00"
         },
         {
             "name": "shipmonk/coverage-guard",
@@ -3258,9 +3258,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "shipmonk/coding-standard": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23221c568e9effaab69fdc663cd78a7c",
+    "content-hash": "f3ce76ddb74ded15068d0dce5365288f",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -101,7 +101,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "editorconfig-checker/editorconfig-checker",
@@ -1214,16 +1214,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -1255,9 +1255,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2025-08-30T15:50:23+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -2809,21 +2809,23 @@
         },
         {
             "name": "shipmonk/coding-standard",
-            "version": "0.2.0",
+            "version": "dev-add-generic-custom-sniffs",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "eabe46b1cf541e24692fb6f4700b7b95da3676ec"
+                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/eabe46b1cf541e24692fb6f4700b7b95da3676ec",
-                "reference": "eabe46b1cf541e24692fb6f4700b7b95da3676ec",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/556e3d2499dec123904ec09d90e5d1d8a2b36844",
+                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844",
                 "shasum": ""
             },
             "require": {
+                "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
-                "slevomat/coding-standard": "^8.25.0"
+                "slevomat/coding-standard": "^8.28.0",
+                "squizlabs/php_codesniffer": "^4.0.1"
             },
             "require-dev": {
                 "editorconfig-checker/editorconfig-checker": "^10.6",
@@ -2841,7 +2843,7 @@
             "type": "phpcodesniffer-standard",
             "autoload": {
                 "psr-4": {
-                    "ShipMonk\\CodingStandard\\": "ShipMonkCodingStandard/"
+                    "ShipMonkCodingStandard\\": "ShipMonkCodingStandard/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2851,9 +2853,9 @@
             "description": "PHP Coding Standard used in ShipMonk",
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
-                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.2.0"
+                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
             },
-            "time": "2025-11-25T11:07:36+00:00"
+            "time": "2026-06-22T07:30:14+00:00"
         },
         {
             "name": "shipmonk/coverage-guard",
@@ -3061,32 +3063,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.25.1",
+            "version": "8.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "4caa5ec5a30b84b2305e80159c710d437f40cc40"
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/4caa5ec5a30b84b2305e80159c710d437f40cc40",
-                "reference": "4caa5ec5a30b84b2305e80159c710d437f40cc40",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.2.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.1",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpdoc-parser": "^2.3.0",
+                "phpstan/phpdoc-parser": "^2.3.2",
                 "squizlabs/php_codesniffer": "^4.0.1"
             },
             "require-dev": {
-                "phing/phing": "3.0.1|3.1.0",
+                "phing/phing": "3.0.1|3.1.2",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.32",
-                "phpstan/phpstan-deprecation-rules": "2.0.3",
-                "phpstan/phpstan-phpunit": "2.0.8",
-                "phpstan/phpstan-strict-rules": "2.0.7",
-                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.36|12.4.4"
+                "phpstan/phpstan": "2.1.54",
+                "phpstan/phpstan-deprecation-rules": "2.0.4",
+                "phpstan/phpstan-phpunit": "2.0.16",
+                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.55|12.5.24"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -3110,7 +3112,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.25.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.29.0"
             },
             "funding": [
                 {
@@ -3122,7 +3124,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-25T18:01:43+00:00"
+            "time": "2026-05-07T05:48:08+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -3256,7 +3258,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "shipmonk/coding-standard": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/ComposerJson.php
+++ b/src/ComposerJson.php
@@ -70,8 +70,8 @@ class ComposerJson
     public array $autoloadExcludeRegexes;
 
     /**
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function __construct(
         string $composerJsonPath,

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -264,8 +264,8 @@ class Configuration
      * @param list<ErrorType::*> $errorTypes
      * @return $this
      *
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function ignoreErrorsOnPath(
         string $path,
@@ -286,8 +286,8 @@ class Configuration
      * @param list<ErrorType::*> $errorTypes
      * @return $this
      *
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function ignoreErrorsOnPaths(
         array $paths,
@@ -391,8 +391,8 @@ class Configuration
      * @param list<ErrorType::*> $errorTypes
      * @return $this
      *
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function ignoreErrorsOnPackageAndPath(
         string $packageName,
@@ -409,8 +409,8 @@ class Configuration
      * @param list<ErrorType::*> $errorTypes
      * @return $this
      *
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function ignoreErrorsOnExtensionAndPath(
         string $extension,
@@ -426,8 +426,8 @@ class Configuration
     /**
      * @param list<ErrorType::*> $errorTypes
      *
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     private function ignoreErrorsOnDependencyAndPath(
         string $dependency,
@@ -449,8 +449,8 @@ class Configuration
      * @param list<ErrorType::*> $errorTypes
      * @return $this
      *
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function ignoreErrorsOnPackageAndPaths(
         string $packageName,
@@ -470,8 +470,8 @@ class Configuration
      * @param list<ErrorType::*> $errorTypes
      * @return $this
      *
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function ignoreErrorsOnExtensionAndPaths(
         string $extension,
@@ -492,8 +492,8 @@ class Configuration
      * @param list<ErrorType::*> $errorTypes
      * @return $this
      *
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function ignoreErrorsOnPackagesAndPaths(
         array $packages,
@@ -514,8 +514,8 @@ class Configuration
      * @param list<ErrorType::*> $errorTypes
      * @return $this
      *
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function ignoreErrorsOnExtensionsAndPaths(
         array $extensions,

--- a/src/Initializer.php
+++ b/src/Initializer.php
@@ -158,8 +158,8 @@ EOD;
     }
 
     /**
-     * @throws InvalidPathException
      * @throws InvalidConfigException
+     * @throws InvalidPathException
      */
     public function initComposerJson(CliOptions $options): ComposerJson
     {


### PR DESCRIPTION
Bumps `shipmonk/coding-standard` to `^0.3.0`, which adds the new ShipMonk custom sniffs, and applies the auto-fixable results (`phpcbf` — catch/throws ordering etc.). No manual changes required.

Co-Authored-By: Claude Code