### PR TITLE
E2E: default to PHP 8.5, downgrade only where needed

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,6 @@ jobs:
                 include:
                     -
                         repo: TomasVotruba/unused-public
-                        php: 8.5
                     -
                         repo: VincentLanglet/Twig-CS-Fixer
                     -
@@ -39,7 +38,6 @@ jobs:
                         cdaArgs: --disable-ext-analysis
                     -
                         repo: mimmi20/ios-build
-                        php: 8.5
                     -
                         repo: mimmi20/laminas-form-element-group
                     -
@@ -66,7 +64,6 @@ jobs:
                         repo: mimmi20/laminasviewrenderer-vite-url
                     -
                         repo: mimmi20/macos-build
-                        php: 8.5
                     -
                         repo: mimmi20/mezzio-generic-authorization
                     -
@@ -163,7 +160,7 @@ jobs:
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: ${{ matrix.php || '8.3' }}
+                    php-version: ${{ matrix.php || '8.5' }}
                     ini-file: ${{ matrix.iniFile || 'development' }}
 
             -

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,7 @@ jobs:
                 include:
                     -
                         repo: TomasVotruba/unused-public
+                        php: 8.5
                     -
                         repo: VincentLanglet/Twig-CS-Fixer
                     -
@@ -38,6 +39,7 @@ jobs:
                         cdaArgs: --disable-ext-analysis
                     -
                         repo: mimmi20/ios-build
+                        php: 8.5
                     -
                         repo: mimmi20/laminas-form-element-group
                     -
@@ -64,6 +66,7 @@ jobs:
                         repo: mimmi20/laminasviewrenderer-vite-url
                     -
                         repo: mimmi20/macos-build
+                        php: 8.5
                     -
                         repo: mimmi20/mezzio-generic-authorization
                     -

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,6 +108,7 @@ jobs:
                         repo: qossmic/deptrac-src
                     -
                         repo: rectorphp/rector-src
+                        php: 8.3 # uses symfony/polyfill-php84, which is a no-op (and thus reported unused) on PHP >= 8.4
                     -
                         repo: rectorphp/swiss-knife
                     -


### PR DESCRIPTION
Reframe of the e2e PHP strategy: instead of bumping the handful of jobs that pull PHPUnit 12, make **8.5 the default** so we exercise the analyser against the newest PHP, and pin individual repos *down* only where they genuinely fail under 8.5.

### Changes
- Default e2e PHP: `8.3` → `8.5`.
- Existing explicit override (`phpstan/phpstan-src`, `php: 8.5`) kept as-is.
- `rectorphp/rector-src` pinned **down** to `php: 8.3`.

### Why each pin
**Original 8.3 failures, now fixed for free by the 8.5 default** (`TomasVotruba/unused-public`, `mimmi20/ios-build`, `mimmi20/macos-build`): these pull PHPUnit 12 via `composer install --ignore-platform-reqs`, whose `TestCase.php` uses PHP 8.4+ syntax (`new Foo()->bar()`). Under 8.3 the analyser parse-errored on their `vendor/` and exited 255; under 8.5 they parse and pass.

**New 8.5 failure → `rectorphp/rector-src` pinned to 8.3:** under 8.5 the analyser correctly reports `symfony/polyfill-php84` as unused — the polyfill's bootstrap is a no-op on PHP >= 8.4 (the 8.4 features it backfills are native), so no symbols resolve to it. Pinning to 8.3 keeps the polyfill live so it's detected as used.

Environmental/CI-only change — no analyser code touched. All checks green.

Co-Authored-By: Claude Code