### PR TITLE
Fix crash when reflecting a class with a missing parent

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,6 +16,7 @@ parameters:
     excludePaths:
         analyseAndScan:
             - tests/data/not-autoloaded/*
+            - tests/data/autoloaded/broken-parent/* # intentionally extends a non-existent class
     tmpDir: cache/phpstan/
     reportAnyTypeWideningInVarTag: true
     checkMissingCallableSignature: true

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -4,6 +4,7 @@ namespace ShipMonk\ComposerDependencyAnalyser;
 
 use Composer\Autoload\ClassLoader;
 use DirectoryIterator;
+use Error;
 use Generator;
 use LogicException;
 use RecursiveDirectoryIterator;
@@ -480,6 +481,8 @@ class Analyser
             $reflection = new ReflectionClass($usedSymbol); // @phpstan-ignore-line ignore not a class-string, we catch the exception
         } catch (ReflectionException $e) {
             return null; // not autoloadable class
+        } catch (Error $e) { // @phpstan-ignore catch.neverThrown (autoloading the class may fail)
+            return null; // class is autoloadable, but loading it fails (e.g. missing parent class or interface)
         }
 
         $filePath = $reflection->getFileName();

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -771,6 +771,42 @@ class AnalyserTest extends TestCase
         $this->assertResultsWithoutUsages(self::createAnalysisResult(1, []), $result);
     }
 
+    /**
+     * The used class is autoloadable (registered in composer's classmap), but loading it fails
+     * because its parent class is not available. Reflection then throws a plain Error, not a
+     * ReflectionException, which used to crash the whole analysis.
+     *
+     * @see https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/271
+     */
+    public function testReflectionOfClassWithMissingParentDoesNotCrash(): void
+    {
+        $path = realpath(__DIR__ . '/data/not-autoloaded/reflection-error/usage.php');
+        self::assertNotFalse($path);
+
+        $vendorDir = realpath(__DIR__ . '/data/autoloaded/vendor');
+        self::assertNotFalse($vendorDir);
+
+        $config = new Configuration();
+        $config->addPathToScan($path, false);
+
+        $detector = new Analyser(
+            $this->getStopwatchMock(),
+            $vendorDir,
+            [$vendorDir => $this->getClassLoaderMock()],
+            $config,
+            [],
+        );
+        $result = $detector->run();
+
+        self::assertEquals(self::createAnalysisResult(1, [
+            ErrorType::UNKNOWN_CLASS => [
+                'BrokenParent\Package\Clazz' => [
+                    new SymbolUsage($path, 5, SymbolKind::CLASSLIKE),
+                ],
+            ],
+        ]), $result);
+    }
+
     public function testFunctions(): void
     {
         $path = __DIR__ . '/data/not-autoloaded/functions/org/package/fn-def.php';

--- a/tests/data/autoloaded/broken-parent/Clazz.php
+++ b/tests/data/autoloaded/broken-parent/Clazz.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BrokenParent\Package;
+
+// Extends a class that is not available at runtime. The class itself is autoloadable
+// (registered in composer's classmap), but loading it via reflection throws a plain Error,
+// not a ReflectionException. See https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/271
+class Clazz extends NonExistentParent {}

--- a/tests/data/not-autoloaded/reflection-error/usage.php
+++ b/tests/data/not-autoloaded/reflection-error/usage.php
@@ -1,0 +1,5 @@
+<?php
+
+use BrokenParent\Package\Clazz;
+
+new Clazz();


### PR DESCRIPTION
## Problem

Closes #271.

When a used symbol cannot be resolved by any registered Composer `ClassLoader`, `Analyser` falls back to `detectFileByReflection()`, which does `new ReflectionClass($usedSymbol)`. Constructing the reflection triggers **autoloading** of the class. If the class itself is loadable but one of its parents/interfaces is **not** available, PHP throws a plain `Error` ("Class ... not found"), which is a different hierarchy from `ReflectionException` and therefore escaped the existing `catch`, aborting the whole analysis with a fatal error.

Reported case: a project without PHPUnit that references PHPStan's `RuleTestCase` (→ `PHPStanTestCase` → `PHPUnit\Framework\TestCase`, which is missing).

## Fix

Catch `Error` (the narrowest type that covers the autoload failure — not `Throwable`) in `detectFileByReflection()` and treat the symbol as unresolved, the same way an unautoloadable class is handled. The symbol is then reported as an unknown class instead of crashing.

## Test

`testReflectionOfClassWithMissingParentDoesNotCrash` adds a fixture class (`BrokenParent\Package\Clazz`) that `extends` a non-existent parent. It is registered in Composer's classmap (under `tests/data/autoloaded/`), so reflection actually autoloads it and reproduces the exact `Error` from the issue. The test fails (fatal `Error`) without the fix and passes with it — no extra classloader required.

Co-Authored-By: Claude Code