### PR TITLE
E2E: drop stale PHP 8.3 pin for rector-src

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,7 +108,6 @@ jobs:
                         repo: qossmic/deptrac-src
                     -
                         repo: rectorphp/rector-src
-                        php: 8.3 # uses symfony/polyfill-php84, which is a no-op (and thus reported unused) on PHP >= 8.4
                     -
                         repo: rectorphp/swiss-knife
                     -


### PR DESCRIPTION
rector-src now requires PHP `^8.4` and no longer depends on `symfony/polyfill-php84`, so the PHP 8.3 pin (added because the polyfill was reported unused on PHP >= 8.4) is obsolete. Worse, on PHP 8.3 the `Deprecated` attribute and `array_all()` resolve through the transitively installed polyfill, making CDA report it as a shadow dependency — which is what broke the rector e2e job.

Co-Authored-By: Claude Code