### PR TITLE
Add cli & config option to disable virtual packages, eg `psr/log-implementation` (issue #231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This tool reads your `composer.json` and scans all paths listed in `autoload` & 
 - `--show-all-usages` to see all usages
 - `--format` to use different output format, available are: `console` (default), `junit`
 - `--disable-ext-analysis` to disable php extensions analysis (e.g. `ext-xml`)
+- `--ignore-virtual-packages` to ignore virtual packages (e.g. `psr/log-implementation`)
 - `--ignore-unknown-classes` to globally ignore unknown classes
 - `--ignore-unknown-functions` to globally ignore unknown functions
 - `--ignore-shadow-deps` to globally ignore shadow dependencies
@@ -132,6 +133,7 @@ return $config
     ->enableAnalysisOfUnusedDevDependencies() // dev packages are often used only in CI, so this is not enabled by default
     ->disableReportingUnmatchedIgnores() // do not report ignores that never matched any error
     ->disableExtensionsAnalysis() // do not analyse ext-* dependencies
+    ->ignoreVirtualPackages() // ignore virtual packages (e.g. psr/log-implementation) that are never installed under vendor/
 
     //// Use symbols from yaml/xml/neon files
     // - designed for DIC config files (see below)

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -32,9 +32,11 @@ use function get_declared_traits;
 use function get_defined_constants;
 use function get_defined_functions;
 use function in_array;
+use function is_dir;
 use function is_file;
 use function is_string;
 use function str_replace;
+use function str_starts_with;
 use function strlen;
 use function strpos;
 use function strtolower;
@@ -134,9 +136,9 @@ class Analyser
     {
         $this->stopwatch = $stopwatch;
         $this->config = $config;
-        $this->composerJsonDependencies = $this->filterDependencies($composerJsonDependencies, $config);
         $this->vendorDirs = array_keys($classLoaders + [$defaultVendorDir => null]);
         $this->classLoaders = array_values($classLoaders);
+        $this->composerJsonDependencies = $this->filterDependencies($composerJsonDependencies, $config);
 
         $this->initExistingSymbols($config);
     }
@@ -630,10 +632,33 @@ class Analyser
                 continue;
             }
 
+            if ($config->shouldIgnoreVirtualPackages() && $this->isVirtualPackage($dependency)) {
+                continue;
+            }
+
             $filtered[$dependency] = $isDevDependency;
         }
 
         return $filtered;
+    }
+
+    /**
+     * Virtual packages (e.g. psr/log-implementation) are never installed under vendor/;
+     * they are only provided by other packages via composer's "provide" section.
+     */
+    private function isVirtualPackage(string $packageName): bool
+    {
+        if (str_starts_with($packageName, 'ext-')) {
+            return false;
+        }
+
+        foreach ($this->vendorDirs as $vendorDir) {
+            if (is_dir($vendorDir . '/' . $packageName)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 }

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -21,6 +21,7 @@ class Cli
         'help' => false,
         'verbose' => false,
         'disable-ext-analysis' => false,
+        'ignore-virtual-packages' => false,
         'ignore-shadow-deps' => false,
         'ignore-unused-deps' => false,
         'ignore-dev-in-prod-deps' => false,
@@ -160,6 +161,10 @@ class Cli
 
         if (isset($this->providedOptions['disable-ext-analysis'])) {
             $options->disableExtAnalysis = true;
+        }
+
+        if (isset($this->providedOptions['ignore-virtual-packages'])) {
+            $options->ignoreVirtualPackages = true;
         }
 
         if (isset($this->providedOptions['ignore-shadow-deps'])) {

--- a/src/CliOptions.php
+++ b/src/CliOptions.php
@@ -28,6 +28,11 @@ class CliOptions
     /**
      * @var true|null
      */
+    public ?bool $ignoreVirtualPackages = null;
+
+    /**
+     * @var true|null
+     */
     public ?bool $ignoreShadowDeps = null;
 
     /**

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -19,6 +19,8 @@ class Configuration
 
     private bool $extensionsAnalysis = true;
 
+    private bool $ignoreVirtualPackages = false;
+
     private bool $scanComposerAutoloadPaths = true;
 
     private bool $reportUnusedDevDependencies = false;
@@ -100,6 +102,18 @@ class Configuration
     public function disableExtensionsAnalysis(): self
     {
         $this->extensionsAnalysis = false;
+        return $this;
+    }
+
+    /**
+     * Ignore virtual packages (e.g. psr/log-implementation) that are only provided by other packages
+     * and thus never installed under vendor/ and cannot contain any usable code.
+     *
+     * @return $this
+     */
+    public function ignoreVirtualPackages(): self
+    {
+        $this->ignoreVirtualPackages = true;
         return $this;
     }
 
@@ -649,6 +663,11 @@ class Configuration
     public function shouldAnalyseExtensions(): bool
     {
         return $this->extensionsAnalysis;
+    }
+
+    public function shouldIgnoreVirtualPackages(): bool
+    {
+        return $this->ignoreVirtualPackages;
     }
 
     public function shouldScanComposerAutoloadPaths(): bool

--- a/src/Initializer.php
+++ b/src/Initializer.php
@@ -50,6 +50,7 @@ Ignore options:
     --ignore-prod-only-in-dev-deps      Ignore all prod dependency used only in dev paths issues
 
     --disable-ext-analysis              Disable analysis of php extensions (e.g. ext-xml)
+    --ignore-virtual-packages           Ignore virtual packages (e.g. psr/log-implementation)
 EOD;
 
     public function __construct(
@@ -97,6 +98,7 @@ EOD;
         }
 
         $disableExtAnalysis = $options->disableExtAnalysis === true;
+        $ignoreVirtualPackages = $options->ignoreVirtualPackages === true;
         $ignoreUnknownClasses = $options->ignoreUnknownClasses === true;
         $ignoreUnknownFunctions = $options->ignoreUnknownFunctions === true;
         $ignoreUnused = $options->ignoreUnusedDeps === true;
@@ -106,6 +108,10 @@ EOD;
 
         if ($disableExtAnalysis) {
             $config->disableExtensionsAnalysis();
+        }
+
+        if ($ignoreVirtualPackages) {
+            $config->ignoreVirtualPackages();
         }
 
         if ($ignoreUnknownClasses) {

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -689,6 +689,57 @@ class AnalyserTest extends TestCase
         $this->assertResultsWithoutUsages(self::createAnalysisResult(2, []), $result);
     }
 
+    public function testVirtualPackagesAreReportedAsUnusedByDefault(): void
+    {
+        $vendorDir = realpath(__DIR__ . '/data/autoloaded/vendor');
+        self::assertNotFalse($vendorDir);
+
+        $config = new Configuration();
+
+        $detector = new Analyser(
+            $this->getStopwatchMock(),
+            $vendorDir,
+            [$vendorDir => $this->getClassLoaderMock()],
+            $config,
+            [
+                'regular/package' => false,
+                'psr/log-implementation' => false,
+            ],
+        );
+        $result = $detector->run();
+
+        $this->assertResultsWithoutUsages(self::createAnalysisResult(0, [
+            ErrorType::UNUSED_DEPENDENCY => ['psr/log-implementation', 'regular/package'],
+        ]), $result);
+    }
+
+    public function testIgnoreVirtualPackages(): void
+    {
+        $vendorDir = realpath(__DIR__ . '/data/autoloaded/vendor');
+        self::assertNotFalse($vendorDir);
+
+        $config = new Configuration();
+        $config->ignoreVirtualPackages();
+
+        $detector = new Analyser(
+            $this->getStopwatchMock(),
+            $vendorDir,
+            [$vendorDir => $this->getClassLoaderMock()],
+            $config,
+            [
+                'regular/package' => false,
+                'regular/dead' => false,
+                'psr/log-implementation' => false,
+                'psr/http-client-implementation' => false,
+            ],
+        );
+        $result = $detector->run();
+
+        $this->assertResultsWithoutUsages(self::createAnalysisResult(0, [
+            ErrorType::UNUSED_DEPENDENCY => ['regular/dead', 'regular/package'],
+        ]), $result);
+    }
+
     public function testPharSupport(): void
     {
         $canCreatePhar = ini_set('phar.readonly', '0');

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -58,12 +58,13 @@ class CliTest extends TestCase
 
         yield 'valid bool options' => [
             null,
-            ['bin/script.php', '--help', '--verbose', '--ignore-shadow-deps', '--ignore-unused-deps', '--ignore-dev-in-prod-deps', '--ignore-unknown-classes', '--ignore-unknown-functions', '--disable-ext-analysis'],
+            ['bin/script.php', '--help', '--verbose', '--ignore-shadow-deps', '--ignore-unused-deps', '--ignore-dev-in-prod-deps', '--ignore-unknown-classes', '--ignore-unknown-functions', '--disable-ext-analysis', '--ignore-virtual-packages'],
             (static function (): CliOptions {
                 $options = new CliOptions();
                 $options->help = true;
                 $options->verbose = true;
                 $options->disableExtAnalysis = true;
+                $options->ignoreVirtualPackages = true;
                 $options->ignoreShadowDeps = true;
                 $options->ignoreUnusedDeps = true;
                 $options->ignoreDevInProdDeps = true;

--- a/tests/InitializerTest.php
+++ b/tests/InitializerTest.php
@@ -102,6 +102,7 @@ class InitializerTest extends TestCase
         self::assertNull($options->showAllUsages);
         self::assertNull($options->composerJson);
         self::assertNull($options->disableExtAnalysis);
+        self::assertNull($options->ignoreVirtualPackages);
         self::assertNull($options->ignoreProdOnlyInDevDeps);
         self::assertNull($options->ignoreUnknownClasses);
         self::assertNull($options->ignoreUnknownFunctions);
@@ -109,6 +110,23 @@ class InitializerTest extends TestCase
         self::assertNull($options->ignoreShadowDeps);
         self::assertNull($options->ignoreDevInProdDeps);
         self::assertTrue($options->verbose);
+    }
+
+    public function testInitConfigurationIgnoreVirtualPackages(): void
+    {
+        $printer = $this->createMock(Printer::class);
+
+        $composerJson = $this->createMock(ComposerJson::class);
+        $composerJson->autoloadPaths = [__DIR__ => false]; // @phpstan-ignore-line ignore readonly
+        $composerJson->autoloadExcludeRegexes = []; // @phpstan-ignore-line ignore readonly
+
+        $options = new CliOptions();
+        $options->ignoreVirtualPackages = true;
+
+        $initializer = new Initializer(__DIR__, $printer, $printer);
+        $config = $initializer->initConfiguration($options, $composerJson);
+
+        self::assertTrue($config->shouldIgnoreVirtualPackages());
     }
 
     public function testInitCliOptionsHelp(): void


### PR DESCRIPTION
See issue #231

This PR allows `composer-dependency-analyzer` to detect and ignore virtual packages to avoid false positive reports that the package is unused.