### PR TITLE
Never report packages installing no files as unused (virtual packages, metapackages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ This tool reads your `composer.json` and scans all paths listed in `autoload` & 
 ### Unused dependencies
   - Any non-dev dependency is expected to have at least single usage within the scanned paths
   - To avoid false positives here, you might need to adjust scanned paths or ignore some packages by `--config`
+  - Dependencies that install no files are never reported, as they cannot possibly be used from your code:
+    - virtual packages (e.g. `psr/log-implementation`), which exist only via `provide` of another package
+    - metapackages (e.g. `roave/security-advisories`), which ship requirements and conflicts only
+    - this is detected from `vendor/composer/installed.php`, so it requires installed dependencies
 
 ### Dev dependencies in production code
   - For libraries, this is risky as your users might not have those installed

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -132,10 +132,12 @@ class Analyser
         array $composerJsonDependencies,
     )
     {
+        $vendorDirs = array_keys($classLoaders + [$defaultVendorDir => null]);
+
         $this->stopwatch = $stopwatch;
         $this->config = $config;
-        $this->composerJsonDependencies = $this->filterDependencies($composerJsonDependencies, $config);
-        $this->vendorDirs = array_keys($classLoaders + [$defaultVendorDir => null]);
+        $this->composerJsonDependencies = $this->filterDependencies($composerJsonDependencies, $config, new ComposerInstalled($vendorDirs));
+        $this->vendorDirs = $vendorDirs;
         $this->classLoaders = array_values($classLoaders);
 
         $this->initExistingSymbols($config);
@@ -621,6 +623,7 @@ class Analyser
     private function filterDependencies(
         array $dependencies,
         Configuration $config,
+        ComposerInstalled $composerInstalled,
     ): array
     {
         $filtered = [];
@@ -628,6 +631,10 @@ class Analyser
         foreach ($dependencies as $dependency => $isDevDependency) {
             if (!$config->shouldAnalyseExtensions() && strpos($dependency, 'ext-') === 0) {
                 continue;
+            }
+
+            if ($composerInstalled->installsNoFiles($dependency)) {
+                continue; // no files means no symbols, such dependency can never be detected as used
             }
 
             $filtered[$dependency] = $isDevDependency;

--- a/src/ComposerInstalled.php
+++ b/src/ComposerInstalled.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\ComposerDependencyAnalyser;
+
+use function array_diff_key;
+use function is_array;
+use function is_file;
+use function is_string;
+
+/**
+ * Composer's resolved installation state, as dumped into vendor/composer/installed.php
+ *
+ * @see https://getcomposer.org/doc/07-runtime.md#installed-versions
+ */
+class ComposerInstalled
+{
+
+    /**
+     * package name => true
+     *
+     * @var array<string, true>
+     */
+    private array $packagesInstallingNoFiles;
+
+    /**
+     * @param list<string> $vendorDirs
+     */
+    public function __construct(array $vendorDirs)
+    {
+        $installingNoFiles = [];
+        $installingFiles = [];
+
+        foreach ($vendorDirs as $vendorDir) {
+            foreach ($this->readVersions($vendorDir) as $packageName => $packageData) {
+                if (!is_string($packageName) || !is_array($packageData)) {
+                    continue;
+                }
+
+                // virtual packages (e.g. psr/log-implementation) have no package of their own,
+                // metapackages (e.g. roave/security-advisories) have one, but it ships no files
+                $isVirtual = isset($packageData['provided']);
+                $isMetapackage = ($packageData['type'] ?? null) === 'metapackage';
+
+                if ($isVirtual || $isMetapackage) {
+                    $installingNoFiles[$packageName] = true;
+                } else {
+                    $installingFiles[$packageName] = true;
+                }
+            }
+        }
+
+        // the same name may be virtual in one vendor dir, but really installed in another
+        $this->packagesInstallingNoFiles = array_diff_key($installingNoFiles, $installingFiles);
+    }
+
+    /**
+     * Whether the package is known to ship no files at all, and thus can never be used from code.
+     * False for packages missing from installed.php, those are simply not installed.
+     */
+    public function installsNoFiles(string $packageName): bool
+    {
+        return isset($this->packagesInstallingNoFiles[$packageName]);
+    }
+
+    /**
+     * @return array<mixed, mixed>
+     */
+    private function readVersions(string $vendorDir): array
+    {
+        $installedPath = $vendorDir . '/composer/installed.php';
+
+        if (!is_file($installedPath)) {
+            return []; // composer 1 or dependencies not installed at all
+        }
+
+        $installed = require $installedPath;
+
+        if (!is_array($installed)) {
+            return [];
+        }
+
+        $versions = $installed['versions'] ?? null;
+
+        return is_array($versions) ? $versions : [];
+    }
+
+}

--- a/src/ComposerInstalled.php
+++ b/src/ComposerInstalled.php
@@ -36,9 +36,14 @@ class ComposerInstalled
                     continue;
                 }
 
+                // composer merges "provide" and "replace" targets into the very same map as installed
+                // packages, so a really installed package may carry a 'provided' key as well; only an
+                // entry with no version of its own is a virtual package
+                $isInstalledPackage = isset($packageData['version']);
+
                 // virtual packages (e.g. psr/log-implementation) have no package of their own,
                 // metapackages (e.g. roave/security-advisories) have one, but it ships no files
-                $isVirtual = isset($packageData['provided']);
+                $isVirtual = !$isInstalledPackage && isset($packageData['provided']);
                 $isMetapackage = ($packageData['type'] ?? null) === 'metapackage';
 
                 if ($isVirtual || $isMetapackage) {

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -707,6 +707,7 @@ class AnalyserTest extends TestCase
                 'some/metapackage' => false,
                 'illuminate/log' => false,
                 'never/installed' => false,
+                'psr/log' => false,
             ],
         );
         $result = $detector->run();
@@ -715,6 +716,7 @@ class AnalyserTest extends TestCase
             ErrorType::UNUSED_DEPENDENCY => [
                 'illuminate/log',
                 'never/installed',
+                'psr/log',
                 'regular/package',
             ],
         ]), $result);

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -689,6 +689,37 @@ class AnalyserTest extends TestCase
         $this->assertResultsWithoutUsages(self::createAnalysisResult(2, []), $result);
     }
 
+    public function testPackagesInstallingNoFilesAreNeverUnused(): void
+    {
+        $vendorDir = realpath(__DIR__ . '/data/not-autoloaded/composer-installed/vendor');
+        self::assertNotFalse($vendorDir);
+
+        $config = new Configuration();
+
+        $detector = new Analyser(
+            $this->getStopwatchMock(),
+            $vendorDir,
+            [$vendorDir => $this->getClassLoaderMock()],
+            $config,
+            [
+                'regular/package' => false,
+                'psr/log-implementation' => false,
+                'some/metapackage' => false,
+                'illuminate/log' => false,
+                'never/installed' => false,
+            ],
+        );
+        $result = $detector->run();
+
+        $this->assertResultsWithoutUsages(self::createAnalysisResult(0, [
+            ErrorType::UNUSED_DEPENDENCY => [
+                'illuminate/log',
+                'never/installed',
+                'regular/package',
+            ],
+        ]), $result);
+    }
+
     public function testPharSupport(): void
     {
         $canCreatePhar = ini_set('phar.readonly', '0');

--- a/tests/ComposerInstalledTest.php
+++ b/tests/ComposerInstalledTest.php
@@ -40,6 +40,19 @@ class ComposerInstalledTest extends TestCase
         self::assertFalse($installed->installsNoFiles('illuminate/log'));
     }
 
+    /**
+     * Composer merges provide targets into the same map as installed packages, so a really installed
+     * package carries a 'provided' key as soon as any other installed package provides its name
+     *
+     * @see \Composer\Repository\FilesystemRepository::generateInstalledVersions()
+     */
+    public function testInstalledPackageProvidedByAnotherPackageInstallsFiles(): void
+    {
+        $installed = new ComposerInstalled([self::FIXTURE_DIR . '/vendor']);
+
+        self::assertFalse($installed->installsNoFiles('psr/log'));
+    }
+
     public function testUninstalledPackageIsNotReportedAsInstallingNoFiles(): void
     {
         $installed = new ComposerInstalled([self::FIXTURE_DIR . '/vendor']);

--- a/tests/ComposerInstalledTest.php
+++ b/tests/ComposerInstalledTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\ComposerDependencyAnalyser;
+
+use PHPUnit\Framework\TestCase;
+
+class ComposerInstalledTest extends TestCase
+{
+
+    private const FIXTURE_DIR = __DIR__ . '/data/not-autoloaded/composer-installed';
+
+    public function testVirtualPackageInstallsNoFiles(): void
+    {
+        $installed = new ComposerInstalled([self::FIXTURE_DIR . '/vendor']);
+
+        self::assertTrue($installed->installsNoFiles('psr/log-implementation'));
+    }
+
+    public function testMetapackageInstallsNoFiles(): void
+    {
+        $installed = new ComposerInstalled([self::FIXTURE_DIR . '/vendor']);
+
+        self::assertTrue($installed->installsNoFiles('some/metapackage'));
+    }
+
+    public function testRegularPackageInstallsFiles(): void
+    {
+        $installed = new ComposerInstalled([self::FIXTURE_DIR . '/vendor']);
+
+        self::assertFalse($installed->installsNoFiles('regular/package'));
+    }
+
+    /**
+     * Replaced packages do ship files, they just live in the replacing package
+     */
+    public function testReplacedPackageInstallsFiles(): void
+    {
+        $installed = new ComposerInstalled([self::FIXTURE_DIR . '/vendor']);
+
+        self::assertFalse($installed->installsNoFiles('illuminate/log'));
+    }
+
+    public function testUninstalledPackageIsNotReportedAsInstallingNoFiles(): void
+    {
+        $installed = new ComposerInstalled([self::FIXTURE_DIR . '/vendor']);
+
+        self::assertFalse($installed->installsNoFiles('never/heard-of-it'));
+    }
+
+    public function testMissingInstalledPhpIsTolerated(): void
+    {
+        $installed = new ComposerInstalled([self::FIXTURE_DIR]);
+
+        self::assertFalse($installed->installsNoFiles('psr/log-implementation'));
+        self::assertFalse($installed->installsNoFiles('some/metapackage'));
+    }
+
+    public function testPackageInstalledInAnotherVendorDirInstallsFiles(): void
+    {
+        $onlyProvided = new ComposerInstalled([self::FIXTURE_DIR . '/vendor']);
+        self::assertTrue($onlyProvided->installsNoFiles('provided/elsewhere'));
+
+        $alsoInstalled = new ComposerInstalled([
+            self::FIXTURE_DIR . '/vendor',
+            self::FIXTURE_DIR . '/other-vendor',
+        ]);
+        self::assertFalse($alsoInstalled->installsNoFiles('provided/elsewhere'));
+    }
+
+}

--- a/tests/data/not-autoloaded/composer-installed/other-vendor/composer/installed.php
+++ b/tests/data/not-autoloaded/composer-installed/other-vendor/composer/installed.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+// second vendor dir, installs provided/elsewhere for real, see ComposerInstalledTest
+
+return [
+    'versions' => [
+        'provided/elsewhere' => [
+            'pretty_version' => '1.0.0',
+            'version' => '1.0.0.0',
+            'reference' => null,
+            'type' => 'library',
+            'install_path' => __DIR__ . '/../provided/elsewhere',
+            'aliases' => [],
+            'dev_requirement' => false,
+        ],
+    ],
+];

--- a/tests/data/not-autoloaded/composer-installed/vendor/composer/installed.php
+++ b/tests/data/not-autoloaded/composer-installed/vendor/composer/installed.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+// mimics real vendor/composer/installed.php, see ComposerInstalledTest
+
+return [
+    'root' => [
+        'name' => 'shipmonk/fixture',
+        'pretty_version' => 'dev-master',
+        'version' => 'dev-master',
+        'reference' => null,
+        'type' => 'library',
+        'install_path' => __DIR__ . '/../../',
+        'aliases' => [],
+        'dev' => true,
+    ],
+    'versions' => [
+        'regular/package' => [
+            'pretty_version' => '1.0.0',
+            'version' => '1.0.0.0',
+            'reference' => null,
+            'type' => 'library',
+            'install_path' => __DIR__ . '/../regular/package',
+            'aliases' => [],
+            'dev_requirement' => false,
+        ],
+        'some/metapackage' => [
+            'pretty_version' => '1.0.0',
+            'version' => '1.0.0.0',
+            'reference' => null,
+            'type' => 'metapackage',
+            'install_path' => null,
+            'aliases' => [],
+            'dev_requirement' => false,
+        ],
+        'psr/log-implementation' => [
+            'dev_requirement' => false,
+            'provided' => ['1.0|2.0|3.0'],
+        ],
+        'illuminate/log' => [
+            'dev_requirement' => false,
+            'replaced' => ['1.0.0'],
+        ],
+        'provided/elsewhere' => [
+            'dev_requirement' => false,
+            'provided' => ['1.0.0'],
+        ],
+    ],
+];

--- a/tests/data/not-autoloaded/composer-installed/vendor/composer/installed.php
+++ b/tests/data/not-autoloaded/composer-installed/vendor/composer/installed.php
@@ -36,6 +36,17 @@ return [
             'dev_requirement' => false,
             'provided' => ['1.0|2.0|3.0'],
         ],
+        // really installed, but some other installed package declares "provide" for this name too
+        'psr/log' => [
+            'pretty_version' => '3.0.2',
+            'version' => '3.0.2.0',
+            'reference' => null,
+            'type' => 'library',
+            'install_path' => __DIR__ . '/../psr/log',
+            'aliases' => [],
+            'dev_requirement' => false,
+            'provided' => ['1.0.0'],
+        ],
         'illuminate/log' => [
             'dev_requirement' => false,
             'replaced' => ['1.0.0'],


### PR DESCRIPTION
Alternative take on #275, which tackles the same problem via a cli/config option and an `is_dir()` heuristic.

## Why no config/cli option

A virtual package like `psr/log-implementation` ships no files, has no namespace and owns no symbols, so `UNUSED_DEPENDENCY` on it is a false positive 100% of the time. Unlike `--disable-ext-analysis` (a genuine preference), there is no state of the world where someone wants that report — so the off-position of such a flag would always be wrong. This is unconditional here: no `--ignore-virtual-packages`, no `Configuration::ignoreVirtualPackages()`, no `CliOptions` field.

## Why not detect it from the filesystem

#275 infers virtualness from *"has no directory under `vendor/`"*. That conflates four different situations:

| case | ships files? | #275 | this PR |
|---|---|---|---|
| virtual package (`provide`d by another) | no | skipped | skipped |
| metapackage (`type: metapackage`) | no | skipped | skipped |
| `replace`d name (e.g. `illuminate/log`) | yes, in the replacer | skipped | **reported** |
| simply not installed | unknown | skipped | **reported** |

The last row is the reason it cannot be a default in that form: an incomplete `vendor/` would make the tool go quiet about whole dependencies rather than complain.

Reproduced on a project requiring `psr/log-implementation` (virtual), `symfony/polyfill-php72` (metapackage), `monolog/monolog` + `psr/log` (used) and `nette/utils` (truly unused), dev-requiring `nette/schema`, installed with `--no-dev` so `nette/schema` has no vendor dir, with `enableAnalysisOfUnusedDevDependencies()`:

```
=== master ===
Found 4 unused dependencies!
  • nette/schema             <- false positive (not installed)
  • nette/utils              <- correct
  • psr/log-implementation   <- false positive (virtual)
  • symfony/polyfill-php72   <- false positive (metapackage)

=== #275 --ignore-virtual-packages ===
Found 1 unused dependency!
  • nette/utils
                             <- nette/schema silently swallowed

=== this PR ===
Found 2 unused dependencies!
  • nette/schema             <- still reported, it is a different problem
  • nette/utils
```

## How detection works

`vendor/composer/installed.php` already carries composer's resolved answer, so nothing needs guessing. Verified against composer's own writer of that file, `Composer\Repository\FilesystemRepository::generateInstalledVersions()`, which builds the `versions` map in **two relevant passes** (a third one appends `aliases`): pass 1 assigns a full entry per really installed package, pass 2 then merges the `provide`/`replace` targets of every installed package into that *same* map, appending only `dev_requirement`, `provided` and `replaced`. Pass 1 is the only writer of `version`, and it runs only for packages in the physical inventory, so an entry a pass-2 target creates on its own carries no version at all.

That has a consequence worth spelling out, because it is the trap in this whole area: **a `provided` key does not mean the package is virtual.** As soon as any installed package declares `provide` for a name that is itself really installed, that package's own entry gets a `provided` key appended. Pass 2 dumps every `provide` link regardless of whether the solver actually used it. Reproduced with a real `composer install` — a path package declaring `provide: {"psr/log": "1.0.0"}` next to a real `psr/log: ^3.0` requirement yields:

```php
'psr/log' => [
    'pretty_version' => '3.0.2',
    ...
    'install_path' => '.../vendor/composer/../psr/log',   // really installed, code usable
    'provided' => ['1.0.0'],                              // ...and provided by someone else
],
```

So the discriminator is the **absence of a version of its own**, which is composer's own definition. From `InstalledVersions::getPrettyVersion()`:

> If the package is being replaced or provided but is not really installed, null will be returned as version

and its psalm type for the map agrees — every key except `dev_requirement` is optional:

```
versions: array<string, array{pretty_version?: string, version?: string, reference?: string|null,
                              type?: string, install_path?: string, aliases?: string[],
                              dev_requirement: bool, replaced?: string[], provided?: string[]}>
```

Hence:

- no `version` of its own + carries `provided` → virtual package → never reported
- `type => metapackage` → metapackage → never reported (same `isset($p['type']) && ...` idiom composer's own `getInstalledPackagesByType()` uses)
- name absent from the file → not installed → keeps being reported
- anything else, including a really installed package that merely happens to be `provided` → keeps being reported

Two further things fall out of reading that code, both verified:

- **No name-shape guard needed.** Pass 2 skips every `PlatformRepository::isPlatformPackage()` target, and pass 1 only ever sees real packages, so `php`, `ext-*`, `lib-*` and `composer-*-api` can never appear in `versions`. (#275 needs an explicit `str_starts_with($name, 'ext-')` guard precisely because a filesystem probe cannot tell them apart.)
- **`install_path` is not a usable discriminator.** Metapackages get `install_path => null` (composer's own psalm type says `string`, so it is wrong there), which is why detection keys off `version` and `type` instead.

New `ComposerInstalled` class reads this per vendor dir; when several class loaders are registered, a name that is virtual in one vendor dir but really installed in another counts as installed. A missing `installed.php` (composer 1, or dependencies not installed) skips nothing, i.e. today's behaviour. `Factory.php` constructs the vendor repository with `dumpVersions: true` unconditionally, so composer 2 always writes the file — even under `composer install --no-autoloader`, which is more than the tool already needs, because it hard-requires `vendor/autoload.php` to boot at all.

One version caveat: composer 2.0.x writes `pretty_version`, `version`, `aliases` and `reference` only. `type`, `install_path` and `dev_requirement` arrive in 2.1.0. So against a vendor dir dumped by composer 2.0.x the metapackage half degrades to today's behaviour, while virtual detection keeps working, because 2.0.0 does write `provided`.

Shadow dependency detection is untouched — these packages never owned symbols in the first place, so code pulled in transitively by a metapackage still reports as shadow, as #209 asks for.

## Scope note: this also closes #209

Metapackages fall out of the same lookup for free (one extra condition), which is why #209 is bundled in. @stof suggested there an alternative rule: report a metapackage as unused only when all of its own requirements are unused. This PR implements the simpler rule the issue asked for — never report it. Happy to split #209 back out or switch to the recursive rule if you prefer.

## Deliberately out of scope: `replace`

`illuminate/log` and friends keep being reported as unused. Their code does exist, inside `laravel/framework`, so the real fix is attributing a replacer's symbols to the replaced name — a separate change. Skipping them here would also hide a genuinely unused `illuminate/*` requirement.

One corner does not follow that rule, deliberately. A name can be `provided` by one installed package and `replaced` by another while not being installed itself, which a real `composer install` does produce. `provide` wins there, so the name is skipped. That is the better outcome: when the replacer's code is used through the requirement, reporting the name is a false positive, and when nothing is used the replacer itself still gets reported. Composer's own `provide` docs point the same way — using `provide` for a real package name "implies that the code of that package is also shipped, in which case `replace` is generally a better choice" — so the two mechanisms are not cleanly separable by intent.

## Heads-up on upgrade impact

Anyone who worked around these false positives with `ignoreErrorsOnPackage('psr/log-implementation', [ErrorType::UNUSED_DEPENDENCY])` will now get an unmatched-ignore error instead, since `reportUnmatchedIgnores` is on by default. Worth a changelog note / next minor rather than a patch release.

This does happen in the wild. `Setono/economic-php-sdk` and four sibling SDKs ignore `UNUSED_DEPENDENCY` on `psr/http-client-implementation` and `psr/http-factory-implementation`. Measured on that repo: master prints "No composer issues found" and exits 0, this branch prints two unmatched-ignore errors and exits 1.

Closes #231
Closes #209

Co-Authored-By: Claude Code

