### PR TITLE
E2E: drop all mimmi20/* subjects

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,66 +37,6 @@ jobs:
                         repo: inspirum/xml-php
                         cdaArgs: --disable-ext-analysis
                     -
-                        repo: mimmi20/ios-build
-                    -
-                        repo: mimmi20/laminas-form-element-group
-                    -
-                        repo: mimmi20/laminas-form-element-links
-                    -
-                        repo: mimmi20/laminas-form-element-paragraph
-                    -
-                        repo: mimmi20/laminas-module-errorhandling
-                    -
-                        repo: mimmi20/laminas-router-hostname
-                    -
-                        repo: mimmi20/laminasviewrenderer-bootstrap-form
-                    -
-                        repo: mimmi20/laminasviewrenderer-flash-message
-                    -
-                        repo: mimmi20/laminasviewrenderer-helper-htmlelement
-                    -
-                        repo: mimmi20/laminasviewrenderer-helper-partialrenderer
-                    -
-                        repo: mimmi20/laminasviewrenderer-js-log
-                    -
-                        repo: mimmi20/laminasviewrenderer-revision
-                    -
-                        repo: mimmi20/laminasviewrenderer-vite-url
-                    -
-                        repo: mimmi20/macos-build
-                    -
-                        repo: mimmi20/mezzio-generic-authorization
-                    -
-                        repo: mimmi20/mezzio-generic-authorization-acl
-                    -
-                        repo: mimmi20/mezzio-navigation
-                    -
-                        repo: mimmi20/mezzio-navigation-laminasviewrenderer
-                    -
-                        repo: mimmi20/mezzio-navigation-laminasviewrenderer-bootstrap
-                    -
-                        repo: mimmi20/mezzio-router-laminasrouter-factory
-                    -
-                        repo: mimmi20/mezzio-setlocale-middleware
-                    -
-                        repo: mimmi20/monolog-callbackfilterhandler
-                    -
-                        repo: mimmi20/monolog-streamformatter
-                    -
-                        repo: mimmi20/navigation-helper-acceptpage
-                    -
-                        repo: mimmi20/navigation-helper-containerparser
-                    -
-                        repo: mimmi20/navigation-helper-converttopages
-                    -
-                        repo: mimmi20/navigation-helper-findactive
-                    -
-                        repo: mimmi20/navigation-helper-findfromproperty
-                    -
-                        repo: mimmi20/navigation-helper-findroot
-                    -
-                        repo: mimmi20/navigation-helper-htmlify
-                    -
                         repo: numero2/contao-opengraph3
                         cdaArgs: --config=depcheck.php
                     -
@@ -172,15 +112,6 @@ jobs:
                 working-directory: ${{ matrix.repo }}
                 run: |
                     echo "$(jq --indent 4 '.config += {"prepend-autoloader": false}' composer.json)" > composer.json
-
-            -
-                # abandoned rector/type-perfect declares the same PSR-4 prefix as its successor
-                # tomasvotruba/type-coverage, which wins autoload resolution and makes every
-                # Rector\TypePerfect\* usage attributable only to the successor
-                name: Drop abandoned rector/type-perfect
-                working-directory: ${{ matrix.repo }}
-                run: |
-                    echo "$(jq --indent 4 'del(.require["rector/type-perfect"], .["require-dev"]["rector/type-perfect"])' composer.json)" > composer.json
 
             -
                 name: Install ${{ matrix.repo }} dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -174,6 +174,15 @@ jobs:
                     echo "$(jq --indent 4 '.config += {"prepend-autoloader": false}' composer.json)" > composer.json
 
             -
+                # abandoned rector/type-perfect declares the same PSR-4 prefix as its successor
+                # tomasvotruba/type-coverage, which wins autoload resolution and makes every
+                # Rector\TypePerfect\* usage attributable only to the successor
+                name: Drop abandoned rector/type-perfect
+                working-directory: ${{ matrix.repo }}
+                run: |
+                    echo "$(jq --indent 4 'del(.require["rector/type-perfect"], .["require-dev"]["rector/type-perfect"])' composer.json)" > composer.json
+
+            -
                 name: Install ${{ matrix.repo }} dependencies
                 working-directory: ${{ matrix.repo }}
                 run: composer install --no-progress --no-interaction --ignore-platform-reqs ${{ matrix.composerArgs }}

--- a/scripts/refresh-e2e.php
+++ b/scripts/refresh-e2e.php
@@ -108,12 +108,10 @@ foreach ($result as $index => &$item) {
         || $item['repo'] === 'oveleon/contao-recommendation-bundle'
         || $item['repo'] === 'numero2/contao-marketing-suite' // since 1.8.2 (shadow symfony/contracts via trigger_deprecation)
         || $item['repo'] === 'teamneusta/pimcore-testing-framework' // since 1.8.2 (shadow symfony/contracts via trigger_deprecation)
-        || $item['repo'] === 'mimmi20/browser-detector-version'
-        || $item['repo'] === 'mimmi20/browser-detector'
-        || $item['repo'] === 'mimmi20/coding-standard'
-        || $item['repo'] === 'mimmi20/ua-normalizer'
-        || $item['repo'] === 'mimmi20/ua-browser-type'
-        || $item['repo'] === 'mimmi20/ua-device-type'
+        // all of them require abandoned rector/type-perfect, which declares the same PSR-4 prefix
+        // as its successor tomasvotruba/type-coverage; the successor wins autoload resolution, so
+        // type-perfect is reported unused - a true positive we cannot fix from here
+        || strpos($item['repo'], 'mimmi20/') === 0
         || $item['repo'] === 'oveleon/contao-company-bundle'
         || $item['repo'] === 'oveleon/contao-config-driver-bundle'
         || $item['repo'] === 'oveleon/contao-cookiebar'
@@ -136,7 +134,6 @@ foreach ($result as $index => &$item) {
         || $item['repo'] === 'inspirum/balikobot-php'
         || $item['repo'] === 'idleberg/php-vite-manifest'
         || $item['repo'] === 'phpstan/phpstan-src'
-        || $item['repo'] === 'mimmi20/monolog-factory'
     ) {
         $item['cdaArgs'] = '--disable-ext-analysis ' . ($item['cdaArgs'] ?? '');
     }


### PR DESCRIPTION
All 30 `mimmi20/*` e2e subjects have been failing on every PR since ~2026-07-30 with:

```
Found 1 unused dependency!
  • rector/type-perfect
```

## Cause

`rector/type-perfect` 2.2.0 was abandoned and merged into `tomasvotruba/type-coverage`. Both packages register the **same PSR-4 prefix**, successor first:

```php
// vendor/composer/autoload_psr4.php
Rector\TypePerfect\ => array(
    $vendorDir . /tomasvotruba/type-coverage/packages/type-perfect/src,
    $vendorDir . /rector/type-perfect/src,
),
```

So the successor wins resolution for **all 28 classes** the old package ships — including `rector/type-perfect`'s own self-references inside `vendor/`, which the mimmi20 configs scan. Verified via the real Composer loader (`findFile()`, no execution):

```
type-perfect ships 28 classes
  autoloader resolves to tomasvotruba/type-coverage: 28
  autoloader resolves to rector/type-perfect:         0
```

Not a single line of PHP from `rector/type-perfect` is ever loaded, so **the finding is a true positive** about those repos, not a regression on our side — nothing in `src/` changed since these jobs last passed. The fix belongs upstream (drop `rector/type-perfect`, keep `tomasvotruba/type-coverage`); it is not something we can address from here.

## Change

- Remove the 30 `mimmi20/*` entries from the e2e matrix.
- Exclude them by `mimmi20/` prefix in `scripts/refresh-e2e.php` so a refresh does not reintroduce them. This also subsumes the six mimmi20 repos already listed individually, and drops the now-unreachable `cdaArgs` entry for `mimmi20/monolog-factory`.

Rejected alternative: `--ignore-unused-deps` on those entries. They are the only subjects that enable `enableAnalysisOfUnusedDevDependencies()`, so that would have silently dropped our real-world coverage of unused-dependency detection rather than being honest about the subjects being unusable.

## Notes

- The 30 remaining subjects are unaffected — none of them require `rector/type-perfect` (checked each `composer.json` via the GitHub API).
- Unrelated pre-existing bug, left alone: `scripts/refresh-e2e.php` crashes on dependents not hosted on GitHub (`dogma/dogma`, `itzbund/*`) because `fetchRepository()` destructures an empty `preg_match` result. Reproduces identically on `master`. I verified the new exclusion end-to-end with a locally patched copy: 161 repos generated, zero `mimmi20`.

Co-Authored-By: Claude Code