### PR TITLE
Detect unqualified instantiation in global scope

### DIFF
--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -74,7 +74,7 @@ class UsedSymbolExtractor
         $useStatements = [];
         $useStatementKinds = [];
         $declaredNames = []; // lowercase classlike name => true
-        $unqualifiedNames = []; // name => true, registered only by the global scope fallback below
+        $instantiationLines = []; // name => [line => true], usages registered by the `new Foo` fallback below
 
         $level = 0; // {, }, {$, ${
         $squareLevel = 0; // [, ], #[
@@ -176,17 +176,20 @@ class UsedSymbolExtractor
 
                         $usedSymbols[$kind][$symbolName][] = $token->line;
 
-                    } elseif (
-                        $inGlobalScope
-                        && (
-                            $this->getTokenAfter($pointerAfterName)->id === T_DOUBLE_COLON
-                            || $this->getTokenBefore($pointerBeforeName)->id === T_NEW
-                        )
-                    ) {
-                        // unqualified static access (e.g. Foo::class, Foo::method()) or instantiation (new Foo)
-                        // in global scope; register to allow detection of classes not in $knownSymbols
-                        $usedSymbols[SymbolKind::CLASSLIKE][$name][] = $token->line;
-                        $unqualifiedNames[$name] = true;
+                    } elseif ($inGlobalScope) {
+                        // unqualified static access (e.g. Foo::class, Foo::method(), Foo::CONSTANT) or
+                        // instantiation (new Foo) in global scope
+                        // register to allow detection of classes not in $knownSymbols
+                        $isStaticAccess = $this->getTokenAfter($pointerAfterName)->id === T_DOUBLE_COLON;
+                        $isInstantiation = !$isStaticAccess && $this->getTokenBefore($pointerBeforeName)->id === T_NEW;
+
+                        if ($isStaticAccess || $isInstantiation) {
+                            $usedSymbols[SymbolKind::CLASSLIKE][$name][] = $token->line;
+                        }
+
+                        if ($isInstantiation) {
+                            $instantiationLines[$name][$token->line] = true;
+                        }
                     }
 
                     break;
@@ -222,11 +225,26 @@ class UsedSymbolExtractor
             }
         }
 
-        // an unqualified name that the same file declares always refers to that declaration,
-        // even when the declaration follows the usage (e.g. bootstrap scripts)
-        foreach ($unqualifiedNames as $name => $_) {
-            if (isset($declaredNames[strtolower($name)])) {
+        // `new Foo` refers to a declaration in the same file when that file declares Foo,
+        // because PHP refuses a duplicate declaration; bootstrap scripts even declare Foo
+        // after the instantiation, so this runs once the whole file is known
+        foreach ($instantiationLines as $name => $lines) {
+            if (!isset($declaredNames[strtolower($name)])) {
+                continue;
+            }
+
+            $keptLines = [];
+
+            foreach ($usedSymbols[SymbolKind::CLASSLIKE][$name] ?? [] as $line) {
+                if (!isset($lines[$line])) {
+                    $keptLines[] = $line;
+                }
+            }
+
+            if ($keptLines === []) {
                 unset($usedSymbols[SymbolKind::CLASSLIKE][$name]);
+            } else {
+                $usedSymbols[SymbolKind::CLASSLIKE][$name] = $keptLines;
             }
         }
 

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -171,7 +171,10 @@ class UsedSymbolExtractor
 
                     } elseif (
                         $inGlobalScope
-                        && $this->getTokenAfter($pointerAfterName)->id === T_DOUBLE_COLON
+                        && (
+                            $this->getTokenAfter($pointerAfterName)->id === T_DOUBLE_COLON
+                            || $this->getTokenBefore($pointerBeforeName)->id === T_NEW
+                        )
                     ) {
                         // unqualified static access (e.g., Foo::class, Foo::method(), Foo::CONSTANT) in global scope
                         // register to allow detection of classes not in $knownSymbols

--- a/src/UsedSymbolExtractor.php
+++ b/src/UsedSymbolExtractor.php
@@ -73,6 +73,8 @@ class UsedSymbolExtractor
         $usedSymbols = [];
         $useStatements = [];
         $useStatementKinds = [];
+        $declaredNames = []; // lowercase classlike name => true
+        $unqualifiedNames = []; // name => true, registered only by the global scope fallback below
 
         $level = 0; // {, }, {$, ${
         $squareLevel = 0; // [, ], #[
@@ -93,6 +95,11 @@ class UsedSymbolExtractor
                 case T_ENUM:
                     if (!$this->isKeywordUsedAsConstantName()) {
                         $inClassLevel = $level + 1;
+                        $declaredNameToken = $this->getTokenAfter($this->pointer);
+
+                        if ($declaredNameToken->id === T_STRING) {
+                            $declaredNames[strtolower($declaredNameToken->text)] = true;
+                        }
                     }
 
                     break;
@@ -176,9 +183,10 @@ class UsedSymbolExtractor
                             || $this->getTokenBefore($pointerBeforeName)->id === T_NEW
                         )
                     ) {
-                        // unqualified static access (e.g., Foo::class, Foo::method(), Foo::CONSTANT) in global scope
-                        // register to allow detection of classes not in $knownSymbols
+                        // unqualified static access (e.g. Foo::class, Foo::method()) or instantiation (new Foo)
+                        // in global scope; register to allow detection of classes not in $knownSymbols
                         $usedSymbols[SymbolKind::CLASSLIKE][$name][] = $token->line;
+                        $unqualifiedNames[$name] = true;
                     }
 
                     break;
@@ -212,6 +220,18 @@ class UsedSymbolExtractor
                     $squareLevel--;
                     break;
             }
+        }
+
+        // an unqualified name that the same file declares always refers to that declaration,
+        // even when the declaration follows the usage (e.g. bootstrap scripts)
+        foreach ($unqualifiedNames as $name => $_) {
+            if (isset($declaredNames[strtolower($name)])) {
+                unset($usedSymbols[SymbolKind::CLASSLIKE][$name]);
+            }
+        }
+
+        if (isset($usedSymbols[SymbolKind::CLASSLIKE]) && $usedSymbols[SymbolKind::CLASSLIKE] === []) {
+            unset($usedSymbols[SymbolKind::CLASSLIKE]);
         }
 
         return $usedSymbols;

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -139,6 +139,7 @@ class UsedSymbolExtractorTest extends TestCase
                     'self' => [22], // filtered by Analyser via ignoredSymbols
                     'parent' => [24], // filtered by Analyser via ignoredSymbols
                     'UnknownInstance' => [27, 28, 29], // issue #278: unqualified instantiation in global scope
+                    'SameFileClass' => [35], // line 34 `new SameFileClass()` is dropped, this file declares the class
                 ],
                 SymbolKind::FUNCTION => [
                     'PHPUnit\Framework\assertSame' => [7],

--- a/tests/UsedSymbolExtractorTest.php
+++ b/tests/UsedSymbolExtractorTest.php
@@ -133,10 +133,12 @@ class UsedSymbolExtractorTest extends TestCase
             [
                 SymbolKind::CLASSLIKE => [
                     'DateTimeImmutable' => [3],
+                    'DateTime' => [4], // issue #278: unqualified instantiation in global scope
                     'PHPUnit\Framework\Error' => [5],
                     'UnknownClass' => [17, 18, 19], // issue #224: unqualified static access in global scope
                     'self' => [22], // filtered by Analyser via ignoredSymbols
                     'parent' => [24], // filtered by Analyser via ignoredSymbols
+                    'UnknownInstance' => [27, 28, 29], // issue #278: unqualified instantiation in global scope
                 ],
                 SymbolKind::FUNCTION => [
                     'PHPUnit\Framework\assertSame' => [7],

--- a/tests/data/not-autoloaded/used-symbols/global-namespace.php
+++ b/tests/data/not-autoloaded/used-symbols/global-namespace.php
@@ -22,3 +22,8 @@ UnknownClass::CONSTANT;
 self::FOO;
 static::bar();
 parent::__construct();
+
+// Test for issue #278: unqualified instantiation in global scope
+new UnknownInstance();
+new UnknownInstance;
+new /* comment */ UnknownInstance();

--- a/tests/data/not-autoloaded/used-symbols/global-namespace.php
+++ b/tests/data/not-autoloaded/used-symbols/global-namespace.php
@@ -28,8 +28,9 @@ new UnknownInstance();
 new UnknownInstance;
 new /* comment */ UnknownInstance();
 
-// A name declared by this file is never a dependency, even when declared after the usage
-// (e.g. rectorphp/rector-src bin/rector.php)
+// `new` on a name that this file declares is not a dependency, even when the declaration
+// follows the usage (e.g. rectorphp/rector-src bin/rector.php).
+// The static access form keeps the pre-existing behaviour and is still reported.
 new SameFileClass();
 SameFileClass::create();
 final class SameFileClass {}

--- a/tests/data/not-autoloaded/used-symbols/global-namespace.php
+++ b/tests/data/not-autoloaded/used-symbols/global-namespace.php
@@ -27,3 +27,9 @@ parent::__construct();
 new UnknownInstance();
 new UnknownInstance;
 new /* comment */ UnknownInstance();
+
+// A name declared by this file is never a dependency, even when declared after the usage
+// (e.g. rectorphp/rector-src bin/rector.php)
+new SameFileClass();
+SameFileClass::create();
+final class SameFileClass {}


### PR DESCRIPTION
## Summary

In a file without a namespace, a bare class name is a `T_STRING` token. `UsedSymbolExtractor::parseUsedSymbols()` registered such a name only in three conditions: a `use` statement declares it, `$knownSymbols` contains it, or a `T_DOUBLE_COLON` token follows it. Thus `new Foo()` produced no usage, and packages with non-namespaced classes were reported as unused. `$knownSymbols` holds only extension symbols and runtime-loaded global functions, so classes that load lazily from the classmap are always absent from it.

The change has two parts:

1. **Add a `T_NEW` look-behind** next to the `T_DOUBLE_COLON` look-ahead. A bare name after `new` in global scope is always a classlike. Same trade-off that #243 accepted for `Foo::`.
2. **Drop `new Foo` usages when the same file declares `Foo`.** PHP refuses a duplicate declaration, so such a name always refers to the declaration in the file. The filter runs after the scan, because the declaration can follow the usage.

Fixes #278

## Why part 2 exists

Part 1 alone broke the `rectorphp/rector-src` E2E job. Its `bin/rector.php` does this:

```php
$autoloadIncluder = new AutoloadIncluder();   // line 29
// ...
final class AutoloadIncluder { /* ... */ }    // line 32
```

The class does not autoload, so the analyser reported `Found 1 unknown class! • AutoloadIncluder`. Bootstrap scripts use this shape often.

## The branch adds detections and removes none

The filter deliberately applies per line and only to the `new Foo` form. An earlier revision dropped the `Foo::` form for the same names too. That is a genuine false positive, but downstream projects already ignore it in their own config, so the removal made those entries unmatched and failed two E2E jobs:

| project | file | shape |
| --- | --- | --- |
| rectorphp/rector-src | `build/config/config-downgrade.php` | `DowngradeRectorConfig::DEPENDENCY_EXCLUDE_PATHS`, class declared below |
| sensiolabs/GotenbergBundle | `docs/generate.php` | `BuilderParser::BUILDERS`, class declared above |

I kept those reports as they are. **The `Foo::` false positive deserves a separate PR**, because it invalidates ignore entries in dependent configs and needs a release note. Tell me if you want it here instead.

## Verification

- Repro from the issue (`pear/log` + `new Log_null('test')`) reported `1 unused dependency`. It is now clean, and `--dump-usages 'pear/*'` shows `Log_null`.
- Ran the extractor on the three real E2E files above. `bin/rector.php` loses only `AutoloadIncluder`. The other two keep their output unchanged.
- `composer check` is green.
- Measured over 114 539 local vendor PHP files, 5 002 of them without a namespace: **85 detections added in 73 files, 0 removed.** All added names but one are built-in classes (`RuntimeException`, `Exception`, `ReflectionException`, `TypeError`, …) that `Analyser::$ignoredSymbols` discards.
- No false positive on `new $var()`, `new (expr)()`, `new class {}` or `$o->new`. A comment between `new` and the name is safe, because `getTokenBefore()` skips ignorable tokens. An anonymous class declares no name.

## Notes

- This does **not** fix #253 (`new Value()` with a colliding global function). That case leaves the `isset($knownSymbols[$lowerName])` branch earlier, so it needs the context-based kind resolution of #265. Worth noting: a same-file filter addresses the *root* of both #253 and #264 from a different angle, because both repros declare the colliding symbol in the scanned file itself.
- Global scope still misses many other unqualified classlike positions: `instanceof`, `extends`, `implements`, `catch`, parameter/property/return types, attributes and trait `use`. A follow-up can add the unambiguous ones (`T_INSTANCEOF`/`T_EXTENDS`/`T_IMPLEMENTS` look-behind, and a `T_VARIABLE` look-ahead for type declarations). Comma lists and return types need signature state, so pure look-around cannot solve them.
- Separate defect found during the analysis: `$inGlobalScope` becomes `false` on any `T_NAMESPACE` token and never returns to `true`. An explicit global block `namespace { ... }` thus loses even the current `Foo::` detection.

Co-Authored-By: Claude Code
